### PR TITLE
chore: add bilingual GitHub issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,38 @@
+name: Bug report / Bug 反馈
+description: Report something not working as expected. 报告产品行为异常。
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Bug 反馈 · Bug report
+        请描述问题，可附上复现步骤与截图。Describe the issue; steps and screenshots are optional.
+  - type: textarea
+    id: description
+    attributes:
+      label: 问题描述 / Description
+      description: 什么坏了、影响是什么？What is broken and its impact?
+      placeholder: "示例：打开设置页时崩溃，无法进入模型配置。Example: App crashes when opening Settings → Model config."
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: 复现步骤 / Steps to reproduce
+      description: 选填。Steps are optional.
+      placeholder: |-
+        示例 / Example:
+        1. 打开应用 / Open the app
+        2. 进入设置 → 模型配置 / Open Settings → Model config
+        3. 点击“添加服务” / Click “Add service”
+        4. 应用崩溃 / App crashes
+      render: bash
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 截图 / Screenshots
+      description: 选填，可拖拽图片。Optional; drag & drop images.
+      placeholder: "![截图](url)"
+      render: markdown

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,4 @@
+# Issue 选择器行为配置 / Issue picker behaviour for this repository.
+# 仅允许使用模板提交；禁止空白 issue。Only templates allowed; no blank issues.
+
+blank_issues_enabled: false

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,29 @@
+name: Feature request / 功能请求
+description: Suggest an enhancement or ask a question. 建议新功能或提出问题。
+title: "[Feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        功能请求 · Feature request
+        请描述你的需求，可附上草图。Describe your need; a sketch is optional.
+  - type: textarea
+    id: requirement
+    attributes:
+      label: 需求 / Requirement
+      description: 你希望有什么功能或改进？What feature or change do you want?
+      placeholder: |-
+        示例 / Example:
+        希望能按会话单独设置模型，而不是全局一个模型。
+        I want to set the model per session instead of one global model.
+      render: markdown
+    validations:
+      required: true
+  - type: textarea
+    id: sketch
+    attributes:
+      label: 草图 / Sketch
+      description: 选填，可绘制示意或拖拽图片。Optional; sketch or drag & drop an image.
+      placeholder: "![草图](url)"
+      render: markdown


### PR DESCRIPTION
Adds \.github/ISSUE_TEMPLATE/\ as GitHub Issue Forms (.yml) so the New Issue picker offers two clean, bilingual forms:

- **feature_request.yml** — 功能请求: 需求 / Requirement (required, with example) + 草图 / Sketch (optional).
- **bug_report.yml** — Bug 反馈: 问题描述 / Description (required, with example), 复现步骤 / Steps (optional, with example), 截图 / Screenshots (optional).
- **config.yml** — disables blank issues (no Discussions link).

All copy is bilingual (简体中文 + English), minimal fields, and non-image fields include example placeholders.

> Requires the \enhancement\ and \ug\ labels to exist on the target repo for auto-labelling (labels not defined are silently ignored).

Submitting from my fork branch \pr/issue-templates\ based on the latest \origin/main\ \56318cfd\.