### PR TITLE
feat(desktop): move the context usage inspector into the composer toolbar

### DIFF
--- a/apps/desktop/src/components/ChatTranscript.tsx
+++ b/apps/desktop/src/components/ChatTranscript.tsx
@@ -194,7 +194,7 @@ type ContextPopoverPosition = {
   left: number;
 };
 
-function ContextUsageInspector({
+export function ContextUsageInspector({
   usage,
   turnUsage,
   contextWindow,
@@ -383,20 +383,14 @@ function ContextUsageInspector({
       }
     >
       <div className="context-inspector-heading">
-        <div className="context-inspector-heading-copy">
-          <span className="context-inspector-eyebrow">
-            {t("chat.usageContextLabel")}
-          </span>
-          <strong>
-            {t("chat.usageContextLeft", {
-              count: formatTokenCount(context.remainingTokens),
-            })}
-          </strong>
-        </div>
-        <div className="context-inspector-remaining">
-          <strong>{context.remainingPercent}%</strong>
-          <span>{t("chat.usageContextRemaining")}</span>
-        </div>
+        <strong className="context-inspector-heading-value">
+          {t("chat.usageContextLeft", {
+            count: formatTokenCount(context.remainingTokens),
+          })}
+        </strong>
+        <strong className="context-inspector-heading-percent">
+          {context.remainingPercent}%
+        </strong>
       </div>
       <div className="context-inspector-window">
         <span>{t("chat.usageContextWindow")}</span>
@@ -528,9 +522,8 @@ function ContextUsageInspector({
             }
           />
         </svg>
-        <span className="context-inspector-trigger-copy">
-          <span>{t("chat.usageContextLabel")}</span>
-          <strong>{context.remainingPercent}%</strong>
+        <span className="context-inspector-ring-value">
+          {context.remainingPercent}%
         </span>
       </button>
       {popover && typeof document !== "undefined"
@@ -574,17 +567,6 @@ function MessageMeta({
         <span className="message-meta-chip model" title={modelId}>
           {modelId}
         </span>
-      ) : null}
-      {visibleContextUsage ? (
-        <ContextUsageInspector
-          usage={visibleContextUsage}
-          turnUsage={usage ?? visibleContextUsage}
-          contextWindow={contextWindow}
-          tools={tools}
-          responseDurationMs={responseDurationMs}
-          responseOutputTokens={responseOutputTokens}
-          responseOutputEstimated={responseOutputEstimated}
-        />
       ) : null}
       {!visibleContextUsage && throughput !== undefined ? (
         <span className="message-meta-chip throughput">

--- a/apps/desktop/src/components/Composer.tsx
+++ b/apps/desktop/src/components/Composer.tsx
@@ -14,6 +14,7 @@ import type {
   PermissionMode,
   ProviderPublic,
   ThinkingLevel,
+  UiMessage,
 } from "@pi-desktop/shared";
 import {
   fileReferenceLabel,
@@ -27,6 +28,20 @@ import {
 } from "@pi-desktop/shared";
 import { materializeDraftSession, useAppStore } from "../stores/app-store";
 import type { ComposerDraftSnapshot } from "../lib/composer-smart-stop";
+import type { AssistantTurnEntry } from "../lib/assistant-turns";
+import {
+  assistantTurnResponseDuration,
+  assistantTurnResponseOutputIsEstimated,
+  assistantTurnResponseOutputTokens,
+  assistantTurnTools,
+  assistantTurnUsage,
+  buildTranscriptEntries,
+} from "../lib/assistant-turns";
+import {
+  DEFAULT_CONTEXT_WINDOW,
+  latestMessageUsage,
+  resolveContextWindow,
+} from "../lib/context-usage";
 import {
   HOME_DRAFT_KEY,
   captureComposerDraft,
@@ -57,6 +72,7 @@ import {
   useComposerAutocomplete,
 } from "../hooks/use-composer-autocomplete";
 import { ComposerAutocomplete } from "./ComposerAutocomplete";
+import { ContextUsageInspector } from "./ChatTranscript";
 import { AskToolCard } from "./AskToolCard";
 import { PlanApprovalBar } from "./PlanApprovalBar";
 import {
@@ -609,6 +625,41 @@ export function Composer({
   const workspacePath = useAppStore((s) => s.workspace?.path ?? "");
   const providers = useAppStore((s) => s.providers);
   const providerModels = useAppStore((s) => s.providerModels);
+  const liveMessages = useAppStore((s) => s.messages);
+  // The composer's context inspector mirrors the newest assistant turn, the
+  // same numbers the transcript row used to carry, so the token breakdown
+  // stays reachable at the model picker without scrolling the transcript.
+  const composerContextUsage = useMemo(() => {
+    const latestUsage = latestMessageUsage(liveMessages);
+    if (!latestUsage) return undefined;
+    const latestTurn = [...buildTranscriptEntries(liveMessages).entries]
+      .reverse()
+      .find((entry): entry is AssistantTurnEntry => entry.kind === "assistant-turn");
+    const latestUsageMessage: UiMessage | undefined = [
+      ...liveMessages,
+    ].reverse().find((message) => message.usage);
+    return {
+      usage: latestUsage,
+      turnUsage:
+        (latestTurn ? assistantTurnUsage(latestTurn) : undefined) ?? latestUsage,
+      contextWindow: resolveContextWindow(
+        latestUsageMessage?.providerId,
+        latestUsageMessage?.modelId,
+        providerModels,
+        providers,
+      ),
+      tools: latestTurn ? assistantTurnTools(latestTurn) : [],
+      responseDurationMs: latestTurn
+        ? assistantTurnResponseDuration(latestTurn)
+        : undefined,
+      responseOutputTokens: latestTurn
+        ? assistantTurnResponseOutputTokens(latestTurn)
+        : undefined,
+      responseOutputEstimated: latestTurn
+        ? assistantTurnResponseOutputIsEstimated(latestTurn)
+        : false,
+    };
+  }, [liveMessages, providerModels, providers]);
   const loadProviderModels = useAppStore((s) => s.loadProviderModels);
   const configureActiveSession = useAppStore((s) => s.configureActiveSession);
   const showToast = useAppStore((s) => s.showToast);
@@ -2303,6 +2354,9 @@ export function Composer({
             </div>
 
             <div className="composer-right">
+              {composerContextUsage ? (
+                <ContextUsageInspector {...composerContextUsage} />
+              ) : null}
               <div
                 className="composer-model-thinking"
                 ref={modelThinkingRef}

--- a/apps/desktop/src/styles/messages.css
+++ b/apps/desktop/src/styles/messages.css
@@ -1210,7 +1210,7 @@
 .context-inspector-summary-row > strong {
   color: var(--ds-text-muted);
   font-size: var(--text-2xs);
-  font-weight: 400;
+  font-weight: var(--font-weight-normal);
   white-space: nowrap;
 }
 

--- a/apps/desktop/src/styles/messages.css
+++ b/apps/desktop/src/styles/messages.css
@@ -1052,23 +1052,13 @@
   transition: stroke-dashoffset var(--motion-duration-normal) var(--motion-ease-out);
 }
 
-.context-inspector-trigger-copy {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  white-space: nowrap;
-}
-
-.context-inspector-trigger-copy > span {
-  color: var(--ds-text-muted);
-  font-size: var(--text-xs);
-}
-
-.context-inspector-trigger-copy strong {
+.context-inspector-ring-value {
   color: currentColor;
   font-size: var(--text-xs);
-  font-weight: var(--font-weight-strong);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--leading-compact);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
 .context-inspector-popover {
@@ -1108,28 +1098,17 @@
   transition-delay: 0s;
 }
 
-.context-inspector-heading,
-.context-inspector-window,
-.context-inspector-compaction {
+.context-inspector-heading {
   display: flex;
-  align-items: center;
+  align-items: baseline;
   justify-content: space-between;
   gap: 12px;
+  padding-bottom: 10px;
+  border-bottom: 1px solid var(--ds-border-subtle);
 }
 
-.context-inspector-heading-copy {
-  display: grid;
+.context-inspector-heading-value {
   min-width: 0;
-  gap: 4px;
-}
-
-.context-inspector-eyebrow {
-  color: var(--ds-text-muted);
-  font-size: var(--text-2xs);
-  letter-spacing: var(--tracking-wide);
-}
-
-.context-inspector-heading-copy > strong {
   color: var(--ds-text-primary);
   font-size: var(--text-lg);
   font-weight: var(--font-weight-strong);
@@ -1137,43 +1116,46 @@
   font-variant-numeric: tabular-nums;
 }
 
-.context-inspector-remaining {
-  display: grid;
+.context-inspector-heading-percent {
   flex: 0 0 auto;
-  justify-items: end;
-  gap: 3px;
   color: currentColor;
-}
-
-.context-inspector-remaining strong {
-  font-size: var(--text-xl);
+  font-size: var(--text-lg);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-none);
   font-variant-numeric: tabular-nums;
 }
 
-.context-inspector-remaining span {
-  color: var(--ds-text-muted);
-  font-size: var(--text-2xs);
+/*
+ * Every section below the heading is one aligned list — muted micro label on
+ * the left, tabular value on the right — with hairlines between sections.
+ */
+.context-inspector-window,
+.context-inspector-kpis,
+.context-inspector-summary,
+.context-inspector-compaction {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--ds-border-subtle);
 }
 
-/* Sections inside the popover are set apart by space alone (D297). */
 .context-inspector-window {
+  display: flex;
   align-items: baseline;
-  margin-top: 18px;
+  justify-content: space-between;
+  gap: 12px;
   color: var(--ds-text-secondary);
-  font-size: var(--text-2xs);
+  font-size: var(--text-xs);
   font-variant-numeric: tabular-nums;
 }
 
 .context-inspector-window > span:first-child {
   color: var(--ds-text-muted);
+  font-size: var(--text-2xs);
 }
 
 .context-inspector-window strong {
   margin-left: auto;
-  color: var(--ds-text-secondary);
-  font-size: var(--text-xs);
+  color: var(--ds-text-primary);
   font-weight: var(--font-weight-medium);
   white-space: nowrap;
 }
@@ -1184,10 +1166,8 @@
 }
 
 .context-inspector-kpis {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-  margin-top: 14px;
+  display: flex;
+  flex-direction: column;
 }
 
 .context-inspector-kpis > div {
@@ -1195,11 +1175,8 @@
   min-width: 0;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
-}
-
-.context-inspector-kpis > div + div {
-  padding-left: 12px;
+  gap: 12px;
+  padding: 2px 0;
 }
 
 .context-inspector-kpis span {
@@ -1211,29 +1188,29 @@
 
 .context-inspector-kpis strong {
   color: var(--ds-text-primary);
-  font-size: var(--text-sm);
-  font-weight: var(--font-weight-semibold);
+  font-size: var(--text-xs);
+  font-weight: var(--font-weight-medium);
   font-variant-numeric: tabular-nums;
   white-space: nowrap;
 }
 
 .context-inspector-summary {
-  display: grid;
-  gap: 10px;
-  margin-top: 18px;
+  display: flex;
+  flex-direction: column;
 }
 
 .context-inspector-summary-row {
-  display: grid;
-  grid-template-columns: auto minmax(0, 1fr);
+  display: flex;
   align-items: baseline;
+  justify-content: space-between;
   gap: 12px;
+  padding: 2px 0;
 }
 
 .context-inspector-summary-row > strong {
-  color: var(--ds-text-primary);
-  font-size: var(--text-xs-plus);
-  font-weight: var(--font-weight-medium);
+  color: var(--ds-text-muted);
+  font-size: var(--text-2xs);
+  font-weight: 400;
   white-space: nowrap;
 }
 
@@ -1242,9 +1219,9 @@
   min-width: 0;
   flex-wrap: wrap;
   justify-content: flex-end;
-  gap: 4px 10px;
-  color: var(--ds-text-secondary);
-  font-size: var(--text-2xs);
+  gap: 2px 10px;
+  color: var(--ds-text-primary);
+  font-size: var(--text-xs);
   font-variant-numeric: tabular-nums;
   text-align: right;
 }
@@ -1254,7 +1231,10 @@
 }
 
 .context-inspector-compaction {
-  margin-top: 16px;
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 12px;
   color: var(--ds-text-muted);
   font-size: var(--text-2xs);
   font-variant-numeric: tabular-nums;

--- a/apps/desktop/src/styles/messages.css
+++ b/apps/desktop/src/styles/messages.css
@@ -1103,8 +1103,6 @@
   align-items: baseline;
   justify-content: space-between;
   gap: 12px;
-  padding-bottom: 10px;
-  border-bottom: 1px solid var(--ds-border-subtle);
 }
 
 .context-inspector-heading-value {
@@ -1127,7 +1125,9 @@
 
 /*
  * Every section below the heading is one aligned list — muted micro label on
- * the left, tabular value on the right — with hairlines between sections.
+ * the left, tabular value on the right — with hairlines between sections. The
+ * heading carries no rule of its own: the first section's top border already
+ * separates them, and a second line just reads as a double underline.
  */
 .context-inspector-window,
 .context-inspector-kpis,

--- a/apps/desktop/test/transcript-style.test.mjs
+++ b/apps/desktop/test/transcript-style.test.mjs
@@ -304,7 +304,9 @@ test("assistant context inspector keeps a compact summary and retry action wired
   assert.match(transcriptSource, /chat\.usageToolsSummary/);
   assert.match(transcriptSource, /context-inspector-kpis/);
   assert.match(transcriptSource, /context-inspector-window-percent/);
-  assert.match(transcriptSource, /chat\.usageContextRemaining/);
+  // The heading shows the remaining count directly; the standalone
+  // "remaining" sublabel is gone.
+  assert.match(transcriptSource, /chat\.usageContextLeft/);
   assert.match(transcriptSource, /chat\.usageThroughput/);
   assert.match(transcriptSource, /calculateCacheRate/);
   assert.match(transcriptSource, /chat\.usageCacheRate/);


### PR DESCRIPTION
Closes #75，按照 issue 里和 @Tioit-Wang 讨论确认的方向来实现，感谢建议！🙏

## 改动内容

**入口位置**：上下文用量面板的入口从"最新一条助手消息下方"移到**输入框底部工具栏、模型选择器左侧**：

- 触发器保留原来的小圆环，百分比放在圆环右侧（按讨论意见去掉了重复的"上下文"文字标签，数字不再拥挤）
- 数据口径不变，仍然对应当前最新一轮（会话最新 assistant turn），只是位置更顺手

**弹层排版**：把原来四种混排的结构统一成一种节奏——标题行（剩余 tokens + 百分比）+ 统一的"左标签 / 右数值"列表 + 分组分隔线；同时按评论里提到的，修掉了 Title 下方的双线（标题自带的 border-bottom 和第一个区块的 border-top 叠加）。

## 实现方式

- `ContextUsageInspector` 从 `ChatTranscript` 内部组件导出，由 `Composer` 复用：Composer 直接订阅 store 的 `messages`，用转录同款 helper（`buildTranscriptEntries` / `assistantTurnUsage` / `resolveContextWindow` 等）取最新一轮数据，弹层定位逻辑不变
- `MessageMeta` 不再渲染该面板，其余 chip（模型名、吞吐率）行为保持原样
- 触发条件与数据流之外无行为变化，样式全部走既有主题变量

## 效果

改前（面板挂在消息下方）：

![before](https://raw.githubusercontent.com/MakkaPakka12138/PI-Desktop/issue-assets/context-inspector/docs/assets/context-inspector/before.png)

改后（输入框工具栏，模型选择器左侧）：

![after closeup](https://raw.githubusercontent.com/MakkaPakka12138/PI-Desktop/issue-assets/context-inspector/docs/assets/context-inspector/after-closeup.png)

## 验证

- `tsc --noEmit` 通过；agent-runtime / desktop 既有测试不受影响
- 桌面端实际运行验证：chip 常驻工具栏、点击弹出面板、双线已消除
- 共 3 个 commit、4 个文件（`ChatTranscript.tsx` / `Composer.tsx` / `messages.css` / `transcript-style.test.mjs`），不触碰任何请求构造与数据逻辑；后两个 commit 分别处理评论里提到的双线与 CI 的样式令牌/测试契约

哪里不合适随时提，我马上调整。再次感谢！
