### PR TITLE
fix(desktop): keep macOS sidebar glass on the dark source-list material

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -1842,6 +1842,9 @@ function createTray() {
 
 
 function sendToRenderer(channel: string, payload: unknown) {
+  if (channel === IPC.event.pluginChanged) {
+    applyNativeThemeSource({ theme: appThemePreference });
+  }
   if (!IPC_WHITELIST.has(channel)) return;
   const window = mainWindow;
   if (
@@ -2024,6 +2027,31 @@ function applyDeveloperMode(settings?: { developerMode?: unknown } | null) {
   }
 }
 
+/**
+ * Drive Chromium and macOS native chrome (menus, vibrancy) from the same
+ * theme preference the renderer paints. `system` keeps following the OS;
+ * an explicit or plugin base locks the native appearance so a dark dock
+ * cannot sit on a light Liquid Glass plate (D348). Missing `plugin:` themes
+ * fall back to `system`, matching the renderer.
+ */
+function applyNativeThemeSource(settings?: { theme?: unknown } | null) {
+  const preference = settings?.theme;
+  let next: "system" | "light" | "dark" = "system";
+  if (preference === "light" || preference === "dark") {
+    next = preference;
+  } else if (typeof preference === "string" && preference.startsWith("plugin:")) {
+    const pluginTheme = plugins.getThemes().find((theme) => theme.id === preference);
+    if (pluginTheme?.base === "light" || pluginTheme?.base === "dark") {
+      next = pluginTheme.base;
+    }
+  }
+  if (nativeTheme.themeSource === next) return;
+  nativeTheme.themeSource = next;
+  if (process.platform === "darwin" && mainWindow && !mainWindow.isDestroyed()) {
+    mainWindow.setVibrancy("sidebar");
+  }
+}
+
 /** Keep native labels and accelerators aligned with persisted app settings. */
 function applyApplicationMenuSettings(settings?: {
   language?: unknown;
@@ -2048,6 +2076,7 @@ function applyApplicationMenuSettings(settings?: {
       : typeof preference === "string" && preference.startsWith("plugin:")
         ? preference
         : "system";
+  applyNativeThemeSource(settings);
   if (preference === "light" || preference === "dark") {
     pluginPanelTheme = preference;
   } else if (typeof preference === "string" && preference.startsWith("plugin:")) {
@@ -2650,7 +2679,7 @@ async function createWindow() {
       ? {
           titleBarStyle: "hiddenInset" as const,
           trafficLightPosition: { x: 16, y: 16 },
-          vibrancy: "under-window" as const,
+          vibrancy: "sidebar" as const,
           visualEffectState: "followWindow" as const,
           transparent: true,
           backgroundColor: "#00000000",
@@ -6280,6 +6309,7 @@ function registerIpc() {
     applyApplicationMenuSettings(
       validatedSettings as {
         language?: unknown;
+        theme?: unknown;
         keybindings?: unknown;
         developerMode?: unknown;
       } | null,
@@ -7224,7 +7254,7 @@ function registerIpc() {
         errorCode: ErrorCodes.INVALID_ARGUMENT,
       });
     }
-    // macOS uses a transparent under-window with native vibrancy. Do not make
+    // macOS uses a transparent window with native sidebar vibrancy. Do not make
     // this renderer-driven fallback opaque on that platform.
     if (process.platform === "darwin") return { applied: false, theme };
     if (!mainWindow || mainWindow.isDestroyed()) {
@@ -8779,6 +8809,7 @@ app.whenReady().then(async () => {
     try {
       const stored = (await host.call("settings.get")) as {
         language?: unknown;
+        theme?: unknown;
         keybindings?: unknown;
         developerMode?: unknown;
       } | null;

--- a/apps/desktop/src/styles/chrome.css
+++ b/apps/desktop/src/styles/chrome.css
@@ -332,7 +332,7 @@
 }
 
 /*
- * macOS supplies the blur through native under-window vibrancy. The renderer
+ * macOS supplies the blur through native sidebar vibrancy. The renderer
  * only adds a thin tint plus sheen on the sidebar, rail, and boot splash —
  * an opaque splash would flash a painted panel before the glass sidebar.
  * The sheen keeps the material reading as glass; a flat tint looks painted.

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -48,11 +48,11 @@
   /* Codex elevated-primary #212121f5 / color-mix(gray-800 96%, transparent) */
   --ds-bg-composer: color-mix(in oklab, var(--gray-800) 96%, transparent);
   /*
-    macOS sidebar and boot-splash glass (chrome.css). The native vibrancy
-    material carries the blur, so the renderer only adds a thin tint plus a
-    sheen; anything heavier reads as a flat panel and hides the material. Tuned
-    so text-muted still clears 4.5:1 on the brightest backdrop the material can
-    produce.
+    macOS sidebar and boot-splash glass (chrome.css). The native sidebar
+    vibrancy material carries the blur, so the renderer only adds a thin tint
+    plus a sheen; anything heavier reads as a flat panel and hides the
+    material. Tuned so text-muted still clears 4.5:1 on the brightest backdrop
+    the source-list material can produce.
   */
   --ds-sidebar-glass-tint: color-mix(in oklab, var(--ds-bg-sidebar) 40%, transparent);
   --ds-sidebar-glass-sheen-top: color-mix(in oklab, var(--gray-0) 7%, transparent);

--- a/apps/desktop/test/macos-sidebar-vibrancy.test.mjs
+++ b/apps/desktop/test/macos-sidebar-vibrancy.test.mjs
@@ -23,13 +23,25 @@ function styleBlock(selector) {
   return stylesSource.match(new RegExp(`${selector}\\s*\\{[^}]*\\}`))?.[0] ?? "";
 }
 
-test("macOS main window enables native under-window vibrancy only in its platform branch", () => {
+function functionSource(name) {
+  const start = mainSource.indexOf(`function ${name}(`);
+  assert.ok(start >= 0, `expected function ${name}`);
+  const next = mainSource.indexOf("\nfunction ", start + 1);
+  return mainSource.slice(start, next === -1 ? undefined : next);
+}
+
+test("macOS main window enables native sidebar vibrancy only in its platform branch", () => {
   assert.match(macOptions, /titleBarStyle:\s*"hiddenInset"/);
   assert.match(macOptions, /trafficLightPosition:\s*\{ x: 16, y: 16 \}/);
-  assert.match(macOptions, /vibrancy:\s*"under-window"/);
+  assert.match(macOptions, /vibrancy:\s*"sidebar"/);
   assert.match(macOptions, /visualEffectState:\s*"followWindow"/);
   assert.match(macOptions, /transparent:\s*true/);
   assert.match(macOptions, /backgroundColor:\s*"#00000000"/);
+  assert.doesNotMatch(
+    mainWindowBlock,
+    /vibrancy:\s*"under-window"/,
+    "non-mac branch must not set under-window vibrancy",
+  );
 
   // The shared opaque fallback remains in place for Windows/Linux.
   assert.match(
@@ -37,6 +49,45 @@ test("macOS main window enables native under-window vibrancy only in its platfor
     /backgroundColor:\s*nativeTheme\.shouldUseDarkColors \? "#181818" : "#ffffff"/,
   );
   assert.match(mainWindowBlock, /frame: false/);
+  assert.doesNotMatch(
+    mainWindowBlock.replace(macOptions, ""),
+    /vibrancy:\s*"sidebar"/,
+    "sidebar vibrancy stays in the darwin branch",
+  );
+});
+
+test("native theme source maps preferences and only resets vibrancy on change", () => {
+  const applyNative = functionSource("applyNativeThemeSource");
+  const applyMenu = functionSource("applyApplicationMenuSettings");
+  const send = functionSource("sendToRenderer");
+
+  assert.match(applyNative, /let next: "system" \| "light" \| "dark" = "system"/);
+  assert.match(
+    applyNative,
+    /if \(preference === "light" \|\| preference === "dark"\) \{\s*next = preference;/,
+  );
+  assert.match(applyNative, /preference\.startsWith\("plugin:"\)/);
+  assert.match(
+    applyNative,
+    /pluginTheme\?\.base === "light" \|\| pluginTheme\?\.base === "dark"/,
+  );
+  assert.match(applyNative, /next = pluginTheme\.base/);
+  assert.doesNotMatch(
+    applyNative,
+    /next = pluginTheme\?\.base \?\?/,
+    "a missing plugin theme must keep the system default, not a guessed base",
+  );
+  assert.match(applyNative, /if \(nativeTheme\.themeSource === next\) return;/);
+  assert.match(
+    applyNative,
+    /nativeTheme\.themeSource = next;\s*if \(process\.platform === "darwin" && mainWindow && !mainWindow\.isDestroyed\(\)\) \{\s*mainWindow\.setVibrancy\("sidebar"\);/,
+  );
+
+  assert.match(applyMenu, /applyNativeThemeSource\(settings\)/);
+  assert.match(
+    send,
+    /if \(channel === IPC\.event\.pluginChanged\) \{\s*applyNativeThemeSource\(\{ theme: appThemePreference \}\);/,
+  );
 });
 
 test("the macOS startup splash shares the sidebar glass tint and sheen", () => {

--- a/docs/spec/04-ux/07-ui-design-system.md
+++ b/docs/spec/04-ux/07-ui-design-system.md
@@ -624,9 +624,9 @@ plain status text:
 - Exit: 280ms opacity fade (`startup-splash-out`) once `ready` is true, revealing
   the already-mounted shell underneath
 - Reduced motion: near-zero enter/exit and a static full-width bar
-- macOS: the splash is the same glass as the sidebar (D304) — the
+- macOS: the splash is the same glass as the sidebar (D304 / D348) — the
   `--ds-sidebar-glass-tint` fill plus top/bottom sheen over the native
-  `under-window` vibrancy, so the boot surface never flashes an opaque panel
+  `sidebar` vibrancy, so the boot surface never flashes an opaque panel
   ahead of the translucent sidebar. The mounted shell stays hidden under
   the glass until the exit fade, then cross-fades in. Other platforms keep
   the opaque `--ds-bg-primary` fill

--- a/docs/spec/04-ux/08-component-spec.md
+++ b/docs/spec/04-ux/08-component-spec.md
@@ -135,18 +135,20 @@ Outer frame that positions Topbar, Sidebar, MainChat, and WorkPanel. Owns resize
 | Windows | Frameless 46px titlebar; sidebar actions at left, open work-panel collapse in session pane top-right ahead of minimize/maximize/close | None inside the window |
 | Linux | Frameless 46px titlebar; sidebar actions at left, open work-panel collapse in session pane top-right ahead of minimize/maximize/close | None inside the window |
 
-- macOS enables the native Electron `vibrancy: "under-window"` material with
-  `visualEffectState: "followWindow"` and a transparent window backing. Only the
-  `.sidebar` and any rendered `.sidebar-rail` surface are translucent; the
-  renderer adds a thin theme tint (`--ds-sidebar-glass-tint`, 40% dark /
-  55% light) plus a top/bottom sheen. The dock carries no seam or hairline:
-  the glass meets the opaque main pane flush, so the only edge cue is the
-  tint's natural change against the pane. The material carries the blur, so the
-  tint must stay thin — the sheen is what keeps the surface reading as glass
-  rather than a painted panel. `.main-pane`, `.main-titlebar`, and
-  `.conversation-topbar` remain opaque `bg-primary` surfaces, so vibrancy does
-  not spread across the whole window. Windows/Linux retain their existing
-  opaque background and frameless behavior.
+- macOS enables the native Electron `vibrancy: "sidebar"` source-list material
+  with `visualEffectState: "followWindow"` and a transparent window backing.
+  `nativeTheme.themeSource` follows the app theme preference (`system` /
+  `light` / `dark` / plugin base) so the material's light or dark plate matches
+  the renderer. Only the `.sidebar` and any rendered `.sidebar-rail` surface
+  are translucent; the renderer adds a thin theme tint
+  (`--ds-sidebar-glass-tint`, 40% dark / 55% light) plus a top/bottom sheen.
+  The dock carries no seam or hairline: the glass meets the opaque main pane
+  flush, so the only edge cue is the tint's natural change against the pane.
+  The material carries the blur, so the tint must stay thin — the sheen is what
+  keeps the surface reading as glass rather than a painted panel.
+  `.main-pane`, `.main-titlebar`, and `.conversation-topbar` remain opaque
+  `bg-primary` surfaces, so vibrancy does not spread across the whole window.
+  Windows/Linux retain their existing opaque background and frameless behavior.
 - The macOS system menu exposes New Task, Open Project, Settings, Command
   Palette, Sidebar, standard editing, zoom/fullscreen, window, Help, Logs, and
   Check for Updates actions. Windows/Linux expose equivalent product actions

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -3533,7 +3533,7 @@ Each scenario is documented in this format:
 - **Expected**:
   - Before ready: full-window splash with brand mark, shell name, tagline, and accessible starting status (`data-testid="startup-splash"`).
   - After ready: splash exits with a short fade (or instantly under reduced motion) and the main shell (or settings page) is interactive underneath.
-  - On macOS the splash uses the same glass tint and sheen as the sidebar over native `under-window` vibrancy; the mounted shell stays hidden until the splash exit fade, then cross-fades in. Other platforms keep the opaque `--ds-bg-primary` fill.
+  - On macOS the splash uses the same glass tint and sheen as the sidebar over native `sidebar` vibrancy; the mounted shell stays hidden until the splash exit fade, then cross-fades in. Other platforms keep the opaque `--ds-bg-primary` fill.
   - No plain unbranded “Starting…” centered text as the only boot UI.
   - Overlay/dialog enter motion uses shared tokens; reduced motion keeps state changes without decorative duration.
   - If a non-settings bootstrap request fails while the settings read is still
@@ -3541,7 +3541,7 @@ Each scenario is documented in this format:
     settings request itself fails, the active section shows a loading/failure
     state and retry action rather than a blank content pane; retrying after the
     local service recovers restores the controls without leaving Settings.
-- **Specs linked**: `04-ux/07-ui-design-system.md` §8, `04-ux/02-i18n-english-first.md`, decisions-log D146 / D304
+- **Specs linked**: `04-ux/07-ui-design-system.md` §8, `04-ux/02-i18n-english-first.md`, decisions-log D146 / D304 / D348
 - **Acceptance**: A (app startup), Quality
 - **Milestone**: M5
 #### E2E-099: Brand logo follows the active theme
@@ -6432,17 +6432,19 @@ This test plan spec is accepted when:
 ### US-UI-74 macOS native sidebar vibrancy
 - Open the desktop app on macOS in both light and dark appearances with the
   sidebar expanded, then exercise the existing collapse/expand path.
-- Expect the main window to use native `under-window` vibrancy with a thin
-  theme tint behind `.sidebar` and any rendered `.sidebar-rail`: desktop
-  content stays perceptible through the material and the surface carries a
-  top-to-bottom sheen rather than a flat fill. The dock carries no seam or
-  hairline — the glass meets the opaque main pane flush, so no hard divider
-  separates the two panes.
+- Expect the main window to use native `sidebar` vibrancy with a thin
+  theme tint behind `.sidebar` and any rendered `.sidebar-rail`: the material
+  follows the app theme (`nativeTheme.themeSource`), so a dark shell stays on a
+  dark plate and a light shell stays on a light plate. Desktop content stays
+  perceptible through the material and the surface carries a top-to-bottom
+  sheen rather than a flat fill. The dock carries no seam or hairline — the
+  glass meets the opaque main pane flush, so no hard divider separates the two
+  panes.
 - Expect `.main-pane`, `.main-titlebar`, and `.conversation-topbar` to remain
   solid theme surfaces without whole-window transparency or a strong artificial
   blur/card treatment. Sidebar collapse/expand, resize, traffic-light placement,
   and drag/no-drag hit regions remain unchanged.
-- **Specs linked**: `04-ux/08-component-spec.md` §1.7, §3.4
+- **Specs linked**: `04-ux/08-component-spec.md` §1.7, §3.4; decisions-log D304 / D348
 - **Milestone**: M6
 - **Status**: Partially automated (`macos-sidebar-vibrancy.test.mjs` source contract); native visual verification Draft
 

--- a/docs/spec/08-meta/decisions-log.md
+++ b/docs/spec/08-meta/decisions-log.md
@@ -3839,3 +3839,22 @@ D193, and D194.
   heading is remaining tokens plus percentage; inner section rules stay
   forbidden (D297). Assistant meta keeps the model badge.
 - See ADR 0184, `04-ux/08-component-spec.md` §8.3 / §11.3, and E2E-060d.
+
+## 2026-09-08 — macOS sidebar uses the source-list vibrancy material (D348)
+
+- The washed-gray dock reproduced with a **dark app theme and a dark OS** on
+  macOS 26. Syncing `nativeTheme.themeSource` alone would fix dark-app +
+  light-OS; it does not keep `under-window` charcoal when Liquid Glass still
+  paints a light plate under dark appearance. That is why the material changes
+  from D304's `under-window` to `sidebar`.
+- Decision D348: the main window uses Electron `vibrancy: "sidebar"`.
+  `nativeTheme.themeSource` follows the app theme preference (`system` /
+  `light` / `dark` / plugin base) so native menus and the vibrancy plate match
+  the renderer. The assignment is process-wide, so Windows/Linux
+  `shouldUseDarkColors` at window creation also follows the app preference
+  next to `windowSetBackgroundColor`. Re-apply when a `plugin:` theme
+  disappears. Only re-set vibrancy when `themeSource` actually changes. The
+  thin `--ds-sidebar-glass-tint` recipe is unchanged. Amends D304.
+- `macos-sidebar-vibrancy.test.mjs` asserts the sidebar material, preference
+  mapping, settings/pluginChanged apply path, and the darwin live-window
+  vibrancy guard. See `04-ux/08-component-spec.md` §1.7 and US-UI-74 / E2E-076.

--- a/docs/zh-CN/spec/04-ux/07-ui-design-system.md
+++ b/docs/zh-CN/spec/04-ux/07-ui-design-system.md
@@ -576,8 +576,8 @@ shadow-lg:  0 8px 24px rgba(0,0,0,0.12)
 - 退出：一旦 `ready` 为 true，就会出现 280 毫秒不透明度淡出 (`startup-splash-out`)，显露出来
   下面已经安装好的外壳
 - 减少运动：接近零的 enter/exit 和静态全宽条
-- macOS：启动页与侧边栏使用同一套玻璃态（D304）——`--ds-sidebar-glass-tint`
-  底色加上下 sheen，叠在原生 `under-window` vibrancy 之上，这样启动面不会在
+- macOS：启动页与侧边栏使用同一套玻璃态（D304 / D348）——`--ds-sidebar-glass-tint`
+  底色加上下 sheen，叠在原生 `sidebar` vibrancy 之上，这样启动面不会在
   半透明侧边栏之前闪出一块不透明面板。已挂载的 shell 在玻璃下保持隐藏直到退出
   淡出，再交叉淡入。其他平台仍为不透明的 `--ds-bg-primary`
 

--- a/docs/zh-CN/spec/04-ux/08-component-spec.md
+++ b/docs/zh-CN/spec/04-ux/08-component-spec.md
@@ -129,6 +129,13 @@
 | Windows | 无框 46px 标题栏；左侧边栏操作，在 minimize/maximize/close 之前的会话窗格右上角打开工作面板折叠 | 窗户里面没有 |
 | Linux | 无框 46px 标题栏；左侧边栏操作，在 minimize/maximize/close 之前的会话窗格右上角打开工作面板折叠 | 窗户里面没有 |
 
+- macOS 启用 Electron 原生 `vibrancy: "sidebar"` source-list 材质，配合
+  `visualEffectState: "followWindow"` 和透明窗口底。`nativeTheme.themeSource`
+  跟随应用主题偏好（`system` / `light` / `dark` / 插件 base），让毛玻璃底板与
+  渲染器一致。只有 `.sidebar` 和已渲染的 `.sidebar-rail` 半透明；渲染器叠加
+  一层薄主题 tint（`--ds-sidebar-glass-tint`，深色 40% / 浅色 55%）和上下
+  sheen。侧栏与不透明主面板齐平，没有接缝。`.main-pane`、`.main-titlebar` 和
+  `.conversation-topbar` 保持不透明 `bg-primary`。Windows/Linux 仍用不透明底。
 - macOS 系统菜单显示“新建任务”、“打开项目”、“设置”、“命令”
   调色板、侧边栏、标准编辑、zoom/fullscreen、窗口、帮助、日志和
 检查更新操作。 Windows/Linux 公开等效的产品操作

--- a/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
@@ -2722,10 +2722,10 @@ IPC 请求无法关闭。
 - **预期**：
 - 准备之前：带有品牌标志、外壳名称、标语和可访问的启动状态 (`data-testid="startup-splash"`) 的全窗口启动画面。
   - 准备好后：启动画面会短暂淡出（或立即减少运动）退出，并且主外壳（或设置页面）在下面是交互式的。
-  - macOS 上启动页与侧边栏使用同一套玻璃 tint/sheen，叠在原生 `under-window` vibrancy 之上；已挂载的 shell 在退出淡出前保持隐藏，再交叉淡入。其他平台仍为不透明的 `--ds-bg-primary`。
+  - macOS 上启动页与侧边栏使用同一套玻璃 tint/sheen，叠在原生 `sidebar` vibrancy 之上；已挂载的 shell 在退出淡出前保持隐藏，再交叉淡入。其他平台仍为不透明的 `--ds-bg-primary`。
   - 没有简单的无品牌“开始...”居中文本作为唯一的启动 UI。
   - Overlay/dialog 输入动作使用共享令牌；减少的运动可以保持状态变化，而无需装饰持续时间。
-- **链接规格**：`04-ux/07-ui-design-system.md` §8、`04-ux/02-i18n-english-first.md`、决策日志 D146 / D304
+- **链接规格**：`04-ux/07-ui-design-system.md` §8、`04-ux/02-i18n-english-first.md`、决策日志 D146 / D304 / D348
 - **验收**：A（应用程序启动），质量
 - **里程碑**：M5
 #### E2E-099：品牌标志遵循活跃主题

--- a/docs/zh-CN/spec/08-meta/decisions-log.md
+++ b/docs/zh-CN/spec/08-meta/decisions-log.md
@@ -2744,3 +2744,19 @@ D193 和 D194。
 - 紧凑上下文检查器原先挂在最新助手回合下方，会话一滚动就够不着。协作者同意把唯一入口移到模型选择器旁，而不是两处显示同一份数字。
 - 决策 D347：检查器放在输入框右侧工具栏、模型 × 推理芯片左侧，始终对应当前最新一条已报告用量的助手回合。触发器是圆环加百分比。弹层标题为剩余 tokens + 百分比；内部分隔线仍然禁止（D297）。答案下方的助理元只保留模型徽章。
 - 见 ADR 0184、`04-ux/08-component-spec.md` §8.3 / §11.3 与 E2E-060d。
+
+## 2026-09-08 —— macOS 侧边栏改用 source-list vibrancy 材质（D348）
+
+- 洗灰侧栏在 **深色应用主题 + 深色系统外观** 的 macOS 26 上也能复现。只同步
+  `nativeTheme.themeSource` 能修深色应用 + 浅色系统；当 Liquid Glass 在深色外观
+  下仍画出浅色底板时，压不住 D304 的 `under-window`。所以材质改为 `sidebar`。
+- 决策 D348：主窗口改用 Electron `vibrancy: "sidebar"`。
+  `nativeTheme.themeSource` 跟随应用主题偏好（`system` / `light` / `dark` /
+  插件 base），让原生菜单和毛玻璃底板与渲染器一致。该赋值是进程级的，因此
+  Windows/Linux 创建窗口时的 `shouldUseDarkColors` 也会跟随应用偏好，与
+  `windowSetBackgroundColor` 一致。`plugin:` 主题消失时重新 apply。只有
+  `themeSource` 真正变化时才 `setVibrancy`。薄的 `--ds-sidebar-glass-tint`
+  配方不变。修正 D304。
+- `macos-sidebar-vibrancy.test.mjs` 断言 sidebar 材质、偏好映射、设置/
+  pluginChanged 路径，以及 darwin 存活窗口守卫。见
+  `04-ux/08-component-spec.md` §1.7 与 US-UI-74 / E2E-076。


### PR DESCRIPTION
## Summary

On macOS 26, the dark-theme sidebar rendered as a washed light-gray plate beside the opaque dark main pane. `under-window` vibrancy composites a light Liquid Glass backing, and the thin 40% charcoal tint cannot keep the dock in the dark range.

This switches the main window to Electron `vibrancy: "sidebar"` (the source-list material) and drives `nativeTheme.themeSource` from the app theme preference (`system` / `light` / `dark` / plugin base) so native menus and the glass plate match the renderer. The existing `--ds-sidebar-glass-tint` recipe is unchanged.

## Specs

- `docs/spec/04-ux/08-component-spec.md` §1.7
- `docs/spec/04-ux/07-ui-design-system.md` §8.3
- decisions-log D347 (amends D304)
- E2E-076 / US-UI-74

## Validation

- `node --test test/macos-sidebar-vibrancy.test.mjs test/window-background-theme.test.mjs` (5 passed)
- Local unsigned arm64 package rebuilt and confirmed both `PI-Desktop` and `pi-desktop-host-core` are arm64

## Notes

- No protocol, storage, or IPC change
- Does not push to `vastsa/PI-Desktop` `main`; this PR is from `isleei/PI-Desktop` `fix/macos-sidebar-glass`