### PR TITLE
feat(settings): copy custom headers as JSON

### DIFF
--- a/apps/desktop/src/components/settings/ProviderHeadersEditor.tsx
+++ b/apps/desktop/src/components/settings/ProviderHeadersEditor.tsx
@@ -121,20 +121,25 @@ export function ProviderHeadersEditor({
           <Button
             variant="ghost"
             size="sm"
-            onClick={copyHeaders}
-            aria-label={copied ? t("chat.copied") : t("chat.copy")}
-            title={copied ? t("chat.copied") : t("chat.copy")}
-          >
-            {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
-            {copied ? t("chat.copied") : t("chat.copy")}
-          </Button>
-          <Button
-            variant="ghost"
-            size="sm"
             className="provider-setup-header-import"
             onClick={() => fileInputRef.current?.click()}
           >
             {t("settings.importHeadersJson")}
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className={`provider-setup-header-copy${copied ? " is-copied" : ""}`}
+            onClick={copyHeaders}
+            aria-label={
+              copied ? t("settings.headersJsonCopied") : t("settings.copyHeadersJson")
+            }
+            title={
+              copied ? t("settings.headersJsonCopied") : t("settings.copyHeadersJson")
+            }
+          >
+            {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+            {copied ? t("settings.headersJsonCopied") : t("settings.copyHeadersJson")}
           </Button>
           <input
             ref={fileInputRef}

--- a/apps/desktop/src/components/settings/ProviderHeadersEditor.tsx
+++ b/apps/desktop/src/components/settings/ProviderHeadersEditor.tsx
@@ -1,10 +1,12 @@
-import { useRef, useState, type ChangeEvent } from "react";
+import { useEffect, useRef, useState, type ChangeEvent } from "react";
 import { useTranslation } from "react-i18next";
 import { APP_VERSION } from "@pi-desktop/shared";
 import {
   KeyValueRows,
+  pairsToRecord,
   type KeyValuePair,
 } from "../extensions/KeyValueRows";
+import { IconCheck, IconCopy } from "../icons";
 import { Button, Select } from "../ui";
 
 type HeaderPreset = {
@@ -60,6 +62,10 @@ export function ProviderHeadersEditor({
   const { t } = useTranslation();
   const fileInputRef = useRef<HTMLInputElement>(null);
   const [importError, setImportError] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copyTimer = useRef<number | undefined>(undefined);
+
+  useEffect(() => () => window.clearTimeout(copyTimer.current), []);
 
   const addPreset = (key: string) => {
     const preset = HEADER_PRESETS.find((item) => item.key === key);
@@ -68,6 +74,17 @@ export function ProviderHeadersEditor({
       (item) => item.key.trim().toLowerCase() === preset.key.toLowerCase(),
     );
     if (!exists) onChange([...pairs, preset]);
+  };
+
+  const copyHeaders = () => {
+    void navigator.clipboard.writeText(JSON.stringify(pairsToRecord(pairs), null, 2)).then(
+      () => {
+        setCopied(true);
+        window.clearTimeout(copyTimer.current);
+        copyTimer.current = window.setTimeout(() => setCopied(false), 1500);
+      },
+      () => undefined,
+    );
   };
 
   const importJson = async (event: ChangeEvent<HTMLInputElement>) => {
@@ -101,6 +118,16 @@ export function ProviderHeadersEditor({
               </option>
             ))}
           </Select>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={copyHeaders}
+            aria-label={copied ? t("chat.copied") : t("chat.copy")}
+            title={copied ? t("chat.copied") : t("chat.copy")}
+          >
+            {copied ? <IconCheck size={12} /> : <IconCopy size={12} />}
+            {copied ? t("chat.copied") : t("chat.copy")}
+          </Button>
           <Button
             variant="ghost"
             size="sm"

--- a/apps/desktop/src/styles/model-config.css
+++ b/apps/desktop/src/styles/model-config.css
@@ -429,6 +429,8 @@
   justify-content: flex-end;
   gap: 6px;
   min-width: 0;
+  max-width: 100%;
+  flex-wrap: wrap;
 }
 
 .provider-setup-header-preset {
@@ -440,10 +442,22 @@
   font-size: var(--text-2xs);
 }
 
-.provider-setup-header-import {
+.provider-setup-header-import,
+.provider-setup-header-copy {
   flex: none;
+  max-width: 100%;
   padding: 4px 8px;
+  overflow: hidden;
   font-size: var(--text-2xs);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Copy feedback stays compact while making the successful state distinct. */
+.provider-setup-header-copy.is-copied,
+.provider-setup-header-copy.is-success {
+  background: color-mix(in oklab, var(--ds-accent) 12%, transparent);
+  color: var(--ds-accent);
 }
 
 .provider-setup-header-file {
@@ -1507,6 +1521,21 @@
   .provider-setup-head-actions {
     width: 100%;
     justify-content: flex-end;
+  }
+
+  .provider-setup-headers-toolbar {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+
+  .provider-setup-headers-actions {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .provider-setup-header-preset {
+    flex: 1 1 120px;
+    min-width: 0;
   }
 
   .model-provider-row {

--- a/apps/desktop/src/styles/model-config.css
+++ b/apps/desktop/src/styles/model-config.css
@@ -454,8 +454,7 @@
 }
 
 /* Copy feedback stays compact while making the successful state distinct. */
-.provider-setup-header-copy.is-copied,
-.provider-setup-header-copy.is-success {
+.provider-setup-header-copy.is-copied {
   background: color-mix(in oklab, var(--ds-accent) 12%, transparent);
   color: var(--ds-accent);
 }

--- a/apps/desktop/test/provider-form-layout.test.mjs
+++ b/apps/desktop/test/provider-form-layout.test.mjs
@@ -292,8 +292,9 @@ test("Advanced offers presets plus JSON import and copy without redundant helper
   assert.match(headerEditorSource, /JSON\.stringify\(pairsToRecord\(pairs\), null, 2\)/);
   assert.match(headerEditorSource, /navigator\.clipboard\.writeText/);
   assert.match(headerEditorSource, /setCopied\(true\)/);
-  assert.match(headerEditorSource, /t\("chat\.copy"\)/);
-  assert.match(headerEditorSource, /t\("chat\.copied"\)/);
+  assert.match(headerEditorSource, /settings\.copyHeadersJson/);
+  assert.match(headerEditorSource, /settings\.headersJsonCopied/);
+  assert.match(headerEditorSource, /provider-setup-header-copy/);
   assert.doesNotMatch(headerEditorSource, /provider-setup-headers-hint/);
   const advanced = block(".provider-setup-advanced");
   assert.match(advanced, /flex-direction: column/);

--- a/apps/desktop/test/provider-form-layout.test.mjs
+++ b/apps/desktop/test/provider-form-layout.test.mjs
@@ -277,7 +277,7 @@ test("Advanced opens from the dialog header into a separate modal", () => {
   assert.match(modalBody, /overflow-y: auto/);
 });
 
-test("Advanced offers presets and JSON import without redundant helper rows", () => {
+test("Advanced offers presets plus JSON import and copy without redundant helper rows", () => {
   assert.match(setupSource, /ProviderHeadersEditor/);
   assert.match(vendorDialogSource, /ProviderHeadersEditor/);
   assert.match(headerEditorSource, /HEADER_PRESETS/);
@@ -286,6 +286,14 @@ test("Advanced offers presets and JSON import without redundant helper rows", ()
   assert.match(headerEditorSource, /JSON\.parse/);
   assert.match(headerEditorSource, /file\.text\(\)/);
   assert.match(headerEditorSource, /accept="application\/json,\.json"/);
+  // Copy serializes the same normalized record used when headers are persisted,
+  // rather than exposing blank or duplicate editor rows.
+  assert.match(headerEditorSource, /pairsToRecord/);
+  assert.match(headerEditorSource, /JSON\.stringify\(pairsToRecord\(pairs\), null, 2\)/);
+  assert.match(headerEditorSource, /navigator\.clipboard\.writeText/);
+  assert.match(headerEditorSource, /setCopied\(true\)/);
+  assert.match(headerEditorSource, /t\("chat\.copy"\)/);
+  assert.match(headerEditorSource, /t\("chat\.copied"\)/);
   assert.doesNotMatch(headerEditorSource, /provider-setup-headers-hint/);
   const advanced = block(".provider-setup-advanced");
   assert.match(advanced, /flex-direction: column/);

--- a/packages/i18n/src/locales/de/index.ts
+++ b/packages/i18n/src/locales/de/index.ts
@@ -873,6 +873,8 @@ export const de = {
     "headerValue": "Wert",
     "addHeader": "Header hinzufügen",
     "addCommonHeader": "Gemeinsamen Header hinzufügen",
+    "copyHeadersJson": "Header als JSON kopieren",
+    "headersJsonCopied": "Header-JSON kopiert",
     "importHeadersJson": "JSON importieren",
     "headersImportError": "Verwenden Sie ein JSON-Objekt mit Header-Namen und Zeichenfolgenwerten.",
     "next": "Weiter",

--- a/packages/i18n/src/locales/en/index.ts
+++ b/packages/i18n/src/locales/en/index.ts
@@ -892,6 +892,8 @@ export const en = {
     headerValue: "Value",
     addHeader: "Add header",
     addCommonHeader: "Add common header",
+    copyHeadersJson: "Copy headers as JSON",
+    headersJsonCopied: "Headers JSON copied",
     importHeadersJson: "Import JSON",
     headersImportError: "Use a JSON object with header names and string values.",
     next: "Next",

--- a/packages/i18n/src/locales/es/index.ts
+++ b/packages/i18n/src/locales/es/index.ts
@@ -873,6 +873,8 @@ export const es = {
     "headerValue": "Valor",
     "addHeader": "Agregar encabezado",
     "addCommonHeader": "Agregar encabezado común",
+    "copyHeadersJson": "Copiar encabezados como JSON",
+    "headersJsonCopied": "Encabezados JSON copiados",
     "importHeadersJson": "Importar JSON",
     "headersImportError": "Utilice un objeto JSON con nombres de encabezado y valores de cadena.",
     "next": "Siguiente",

--- a/packages/i18n/src/locales/fr/index.ts
+++ b/packages/i18n/src/locales/fr/index.ts
@@ -873,6 +873,8 @@ export const fr = {
     "headerValue": "Valeur",
     "addHeader": "Ajouter un en-tête",
     "addCommonHeader": "Ajouter un en-tête commun",
+    "copyHeadersJson": "Copier les en-têtes au format JSON",
+    "headersJsonCopied": "En-têtes JSON copiés",
     "importHeadersJson": "Importer JSON",
     "headersImportError": "Utilisez un objet JSON avec des noms d'en-tête et des valeurs de chaîne.",
     "next": "Suivant",

--- a/packages/i18n/src/locales/tr/index.ts
+++ b/packages/i18n/src/locales/tr/index.ts
@@ -894,6 +894,8 @@ export const tr = {
     headerValue: "Değer",
     addHeader: "Başlık ekle",
     addCommonHeader: "Yaygın başlık ekle",
+    copyHeadersJson: "Başlıkları JSON olarak kopyala",
+    headersJsonCopied: "Başlıklar JSON olarak kopyalandı",
     importHeadersJson: "JSON içe aktar",
     headersImportError: "JSON, başlık adları ve metin değerlerinden oluşan bir nesne olmalıdır.",
     next: "İleri",

--- a/packages/i18n/src/locales/zh-CN/index.ts
+++ b/packages/i18n/src/locales/zh-CN/index.ts
@@ -884,6 +884,8 @@ export const zhCN = {
     headerValue: "值",
     addHeader: "添加请求头",
     addCommonHeader: "添加常用请求头",
+    copyHeadersJson: "复制请求头 JSON",
+    headersJsonCopied: "请求头 JSON 已复制",
     importHeadersJson: "导入 JSON",
     headersImportError: "JSON 须是由请求头名称和字符串值组成的对象。",
     next: "下一步",

--- a/packages/i18n/src/locales/zh-TW/index.ts
+++ b/packages/i18n/src/locales/zh-TW/index.ts
@@ -884,6 +884,8 @@ export const zhTW = {
     headerValue: "值",
     addHeader: "新增請求頭",
     addCommonHeader: "新增常用請求頭",
+    copyHeadersJson: "複製請求頭 JSON",
+    headersJsonCopied: "已複製請求頭 JSON",
     importHeadersJson: "匯入 JSON",
     headersImportError: "JSON 須是由請求頭名稱和字串值組成的物件。",
     next: "下一步",


### PR DESCRIPTION
## Summary

- add a Copy JSON action to the custom provider Headers editor
- serialize the same normalized header record used for persistence, omitting blank names and preserving last-write-wins behavior
- show localized success feedback and keep the advanced toolbar responsive
- cover the copy contract in the existing provider form layout test

## Validation

- `node --test apps/desktop/test/provider-form-layout.test.mjs` (19 passed)
- `node scripts/check-style-tokens.mjs`
- `git diff --check`
- React/UI and TypeScript/JavaScript review completed with no high-confidence findings

## Notes

- Desktop package `typecheck` and package-manager `lint` could not run in this environment because `pnpm`, `corepack`, and a local `tsc` executable were unavailable. The underlying style-token script was run directly and passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)