### PR TITLE
docs(spec): sync zh-CN provider config schema with English source

### DIFF
--- a/docs/zh-CN/spec/03-runtime/12-provider-config-schema.md
+++ b/docs/zh-CN/spec/03-runtime/12-provider-config-schema.md
@@ -49,10 +49,15 @@
       "additionalProperties": { "type": "string" },
       "maxProperties": 32
     },
-    "userAgent": { "type": "string", "maxLength": 256, "description": "legacy; migrates into headers.User-Agent" },
+    "userAgent": {
+      "type": "string",
+      "maxLength": 256,
+      "description": "legacy; migrates into headers.User-Agent"
+    },
     "apiStyle": {
       "enum": [
         "chat_completions",
+        "opencode_go",
         "responses",
         "anthropic_messages",
         "google_generative_ai",
@@ -78,29 +83,122 @@
       }
     },
     "defaultModelId": { "type": "string" },
+    "models": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["id", "contextWindow", "maxTokens", "thinkingLevels", "defaultThinkingLevel"],
+        "properties": {
+          "id": { "type": "string", "minLength": 1 },
+          "contextWindow": { "type": "integer", "minimum": 1 },
+          "maxTokens": { "type": "integer", "minimum": 1 },
+          "thinkingLevels": {
+            "type": "array",
+            "items": { "enum": ["off", "minimal", "low", "medium", "high", "xhigh", "max"] },
+            "uniqueItems": true
+          },
+          "defaultThinkingLevel": {
+            "type": ["string", "null"],
+            "enum": ["off", "minimal", "low", "medium", "high", "xhigh", "max", null]
+          },
+          "supportsImages": { "type": ["boolean", "null"] },
+          "supportsDocuments": { "type": ["boolean", "null"] },
+          "availableForSubagents": { "type": "boolean", "default": false }
+        }
+      }
+    },
     "createdAt": { "type": "string" },
     "updatedAt": { "type": "string" }
   }
 }
 ```
 
-`compatibility.supportsReasoning` 和
-`compatibility.supportedThinkingLevels` 对于存储的记录保持可读状态
-旧客户端兼容性，但 Electron main 在运行时忽略它们
-模型分辨率。公共提供商形状是从精确的 pi-ai 中丰富的
-代替模型记录。未知的自由形式模型暴露了 `supportsReasoning=false`
-和 `supportedThinkingLevels=["off"]`。原始秘密和内部兼容性
-JSON 保持隐藏状态。
+`compatibility.supportsReasoning` 与 `compatibility.supportedThinkingLevels`
+为了已存储记录和旧客户端的兼容性而保持可读，但 Electron main 在运行时的模型
+解析中会忽略它们。对外的提供商形态由本地的 models.dev 快照丰富。未知的自由
+格式模型最初暴露 `supportsReasoning=false` 与 `supportedThinkingLevels=["off"]`；
+对于确实支持的端点，设置里仍然可以持久化一个显式的思考级别绑定。原始密钥与
+内部兼容性 JSON 保持隐藏。
 
-`authKind: "oauth"` 标记厂商账户行（ADR 0095、D237）：其凭据是保存在
+Anthropic Messages 提供商既可以存服务根地址，也可以存以 `/v1` 结尾的 URL。
+模型发现会保留所配置的路径，并且恰好请求一次 `/v1/models`；运行时在调用
+pi-ai 之前会去掉结尾的 `/v1`，因为 pi-ai 的 Anthropic SDK 会自行把 `/v1` 加到
+messages 路由上。因此两种写法最终都把消息发到所配置服务的 `/v1/messages`
+端点，而不是重复的 `/v1/v1/messages` 路径。
+
+对于 OpenAI 兼容的 Chat Completions 模型，运行时把
+`compat.supportsDeveloperRole` 默认为 `false`，因此即便所选模型支持推理，
+系统指令仍以 `role: "system"` 发送。对于确实接受 `role: "developer"` 的上游，
+解析出的模型记录可以显式把它设为 `true`；这个覆盖的作用域限于该模型。
+
+`authKind: "oauth"` 标记厂商账户行（ADR 0095、D237、D240）：其凭据是保存在
 `secret:provider:<id>:oauth` 下的 OAuth 授权，而不是粘贴的密钥，因此该行
 不为它保存 `secretRef`，并以空密钥启动。最后两个 apiStyle 是厂商账户专用的
 线路 API —— `openai_codex_responses`（Codex 会话封装）与 `pi_messages`
 （radius 网关）—— 自定义提供商对话框不提供它们，因为二者都无法配合手输的
 base URL 与粘贴的密钥工作。厂商行的样式不由厂商固定：GitHub Copilot 同时
 提供 Anthropic、Chat Completions 与 Responses 模型，因此样式跟随所选模型，
-并在每次切换模型时重写。`config_json.oauth.accountLabel` 保存已登录账户的
-非敏感展示标签。
+并在每次切换模型时重写。厂商账户编辑器使用与 AI 服务相同的多模型绑定控件：
+可以选择已认证的目录模型与自定义 id，每条绑定都会把它的上下文窗口、最大输出
+token、思考级别与默认思考级别持久化到 `models` 中。
+`config_json.oauth.accountLabel` 保存已登录账户的非敏感展示标签。
+每次成功登录都会创建一个新行，即使另一行有相同的 `vendorKey`；行 id 界定了
+凭据与运行时绑定的作用域。厂商目录把这些行以 `accounts` 数组暴露出来，含
+`providerId`、可选的非敏感 `accountLabel` 以及一个 `connected` 标志。自定义
+提供商对话框不编辑也不删除 OAuth 行；由"厂商账户"卡片对选中的行调用
+`providers.delete`。
+
+`models` 是该提供商已选中的模型绑定数组。每条绑定拥有自己的上下文/输出上限
+与显式的思考配置。已发布的目录级别会为新选中的已知模型播种，但绑定可以启用
+任意规范级别，这样在目录更新之前，代理端点或新发布的端点也是可配置的。
+`defaultModelId` 仍然是一个读取兼容字段，新建提供商保存时会让它等于第一条
+绑定。当旧记录只有 `defaultModelId` 时，主机在读取时具体化出一条绑定：
+128,000 上下文窗口、8,192 最大输出、不启用任何思考级别、默认值为 null。设置
+编辑器对这条旧绑定仍然渲染全部规范选项，下一次写入就会把显式的绑定数组存进
+`config_json.models`。
+
+就上下文解析而言，那个 128,000 是一个向后兼容的通用种子，而不是隐藏已发布
+长上下文上限的理由。如果 models.dev 现在发布了正数的 `limit.context`，有效的
+运行时窗口与检查器窗口就跟随它；在模型的 Advanced 控件里填写的非默认值仍然
+是一个显式的按模型覆盖。未知 id 继续使用 128,000。
+
+`availableForSubagents` 是每条模型绑定上可选、可持久化的选择加入项。主机的
+读写与归一化会保留 `true`；在该字段出现之前创建的记录默认保持禁用。Electron
+main 正是用这个标志来构建委托模型目录的，因此对它的修改能在提供商编辑与应用
+重启之后继续有效。
+
+`apiStyle: "opencode_go"` 是叠加在 OpenAI 兼容提供商类型之上的一等 OpenCode Go
+预设。它以自己的样式持久化，好让 UI 能识别该服务，但运行时请求使用 OpenAI
+Chat Completions 线路适配器。「服务」下拉在命名的智谱端点旁边提供 OpenCode
+Go。该预设始终使用 `name: "OpenCode Go"` 与
+`baseUrl: "https://opencode.ai/zen/go/v1"`；常见路径是服务 + API key，主机
+以摘要形式展示。模型发现用 Bearer key 调用固定的 `/models` 端点，原始 key
+仍然走正常的密钥库路径。
+
+OpenCode Go（以及任何 `opencode.ai` 主机）要求 LLM 请求带上稳定的
+`x-opencode-session` 标头。Agent 运行时会在会话回合、子代理回合、提示增强
+以及插件的一次性调用上，发送该标头，外加 `x-opencode-client: pi-desktop` 与
+`User-Agent: pi-desktop/<APP_VERSION>`。调用方自带的标头会覆盖 client 与
+User-Agent 的值；缺失或为空的会话标头总是由对话 id 补回。
+
+`headers` 是存放在 `config_json.headers` 中的可选按行映射。留空、省略，或以
+`{}` 更新，都保持适配器默认值（pi-ai 的 `pi (…)` 字符串、Anthropic OAuth 的
+`claude-cli/<version>`，或 OpenCode 的 `pi-desktop/<APP_VERSION>`）。非空映射
+是该行出站 HTTP 的最后写入方——会话回合、子代理、提示增强、插件一次性调用、
+`/models` 发现（包括尚未保存的表单值）、连接测试，以及 OAuth token 刷新。
+一层 fetch 包装是最后的写入方，因此 Codex 与 Anthropic SDK 无法覆盖它。同样
+的值也会被放到流选项标头上，好让 OpenCode 的"调用方优先"规则依然成立。键在
+不区分大小写的意义上唯一，最多 32 项，名称 ≤ 256 字节，值 ≤ 4096 字节，
+不含 CR/LF，名称由字母数字加连字符组成。保留键（`authorization`、
+`proxy-authorization`、`host`、`content-type`、`content-length`、`cookie`、
+`set-cookie`、`connection`、`transfer-encoding`、`te`、`trailer`、`upgrade`、
+`keep-alive`、`x-api-key`、`api-key`、`chatgpt-account-id`、
+`x-opencode-session`）会被拒绝，以免这里冲掉签名或应用路由。它不是密钥。
+遗留的 `config_json.userAgent` 在读取时迁移进 `headers["User-Agent"]`；一旦
+写入 `headers` 就丢弃它。覆盖 Anthropic OAuth 的 `claude-cli/…` User-Agent
+可能导致 Claude Pro/Max 拒绝请求。首次 OAuth 登录不收集标头；它们是在账户
+存在之后才在该账户上编辑的。Advanced UI 是一个紧凑的键/值编辑器，而不是
+一个专门的 User-Agent 字段。
 
 ## 3. 内置供应商预设
 

--- a/docs/zh-CN/spec/03-runtime/12-provider-config-schema.md
+++ b/docs/zh-CN/spec/03-runtime/12-provider-config-schema.md
@@ -180,16 +180,24 @@ type ModelCatalogCacheRecord = {
   capabilities: string[]
   contextWindow?: number
   source: "bundled" | "discovered" | "user"
+  /** 渲染器标注：该行解析自随包的 models.dev 快照。 */
+  catalogSource?: "models.dev"
   updatedAt: string
   raw?: unknown
 }
 ```
 
-上下文窗口解析与 sidecar 保持一致：若 models.dev 已发布正数
-`limit.context`，它会替换旧 binding 中的 128k 通用种子；用户在模型
-Advanced 控件中设置的非默认值仍优先。未知模型继续使用 128k 的保守后备。
+## 5. 随包的 models.dev 快照
 
-## 5. IPC / 主机方法（提供商域）
+原始的公开目录被签入发布资源 `apps/desktop/resources/models.dev/api.json`，
+并打包到 `resources/models.dev/api.json`。`scripts/release.mjs` 抓取并校验
+`https://models.dev/api.json`，然后在创建发布标签之前原子地替换那份签入的
+文件。Electron main 在启动时读取这份随包快照，不产生任何网络 I/O。设置 →
+模型配置可以重新抓取该 URL，但成功的响应只更新当前进程的内存内目录；它绝不
+写入打包资源或用户缓存。缓存读取绝不会把提供商凭据发送给 models.dev。Rust 的
+`models` 表继续只存储归一化的提供商选择行；它不需要为这份原始快照做模式变更。
+
+## 6. IPC / 主机方法（提供商域）
 
 - `providers.list`
 - `providers.get`

--- a/docs/zh-CN/spec/03-runtime/12-provider-config-schema.md
+++ b/docs/zh-CN/spec/03-runtime/12-provider-config-schema.md
@@ -202,25 +202,25 @@ User-Agent 的值；缺失或为空的会话标头总是由对话 id 补回。
 
 ## 3. 内置供应商预设
 
-仅预设预填表单默认值；他们不是一个封闭的世界。
+预设只是预填表单默认值；它们不构成一个封闭的世界。
 
-| 供应商密钥 | 默认协议 | 授权类型 | 需要基本网址 |
+| vendorKey | 默认协议 | authKind | 是否需要 baseUrl |
 |---|---|---|---|
-| 开放性 | 开放性 | api_key | 不 |
-| 人择的 | 人择的 | api_key | 不 |
-| 谷歌 | 谷歌 | api_key | 不 |
-| 开放路由器 | openai_兼容 | api_key_and_base_url | 是的 |
-| 深度搜索 | openai_兼容 | api_key_and_base_url | 是的 |
-| 格罗克 | openai_兼容 | api_key_and_base_url | 是的 |
-| 在一起 | openai_兼容 | api_key_and_base_url | 是的 |
-| 烟花 | openai_兼容 | api_key_and_base_url | 是的 |
-| 米斯塔拉尔 | openai_兼容或本机 | api_key | 可选的 |
-| 赛 | openai_兼容 | api_key_and_base_url | 是的 |
-| azure_openai | openai_兼容 | azure_api_key | 是的 |
-| 基岩 | 基岩 | aws_sdk_默认 | 不 |
-| 奥拉马 | openai_兼容 | 无 | 是的 |
-| 工作室 | openai_兼容 | 无 | 是的 |
-| 定制 | openai_兼容 | api_key_and_base_url | 是的 |
+| openai | openai | api_key | 否 |
+| anthropic | anthropic | api_key | 否 |
+| google | google | api_key | 否 |
+| openrouter | openai_compatible | api_key_and_base_url | 是 |
+| deepseek | openai_compatible | api_key_and_base_url | 是 |
+| groq | openai_compatible | api_key_and_base_url | 是 |
+| together | openai_compatible | api_key_and_base_url | 是 |
+| fireworks | openai_compatible | api_key_and_base_url | 是 |
+| mistral | openai_compatible 或 native | api_key | 可选 |
+| xai | openai_compatible | api_key_and_base_url | 是 |
+| azure_openai | openai_compatible | azure_api_key | 是 |
+| bedrock | bedrock | aws_sdk_default | 否 |
+| ollama | openai_compatible | none | 是 |
+| lmstudio | openai_compatible | none | 是 |
+| custom | openai_compatible | api_key_and_base_url | 是 |
 
 ### 固定 API 风格预设
 
@@ -228,34 +228,33 @@ User-Agent 的值；缺失或为空的会话标头总是由对话 id 补回。
 |---|---|---|---|---|
 | `opencode_go` | `openai_compatible` | `api_key_and_base_url` | `OpenCode Go` | `https://opencode.ai/zen/go/v1` |
 
-OpenCode Go（以及任何 `opencode.ai` 主机）的 LLM 请求必须带稳定的
-`x-opencode-session`。agent-runtime 在会话、子代理、提示增强与插件 one-shot
-上发送该头，并附带 `x-opencode-client: pi-desktop` 与
-`User-Agent: pi-desktop/<APP_VERSION>`。行上可选的 `headers` 会覆盖这些默认值；留空则保持适配器默认。
-
-每行（AI 服务或 OAuth 账户）可在高级选项中用键值行编辑自定义请求头。空映射保持 pi-ai / `claude-cli` / OpenCode 默认。fetch 包装器是最后写入者，因此 Codex 与 Anthropic SDK 无法覆盖。禁止 `Authorization` / `Host` / `Content-Type` 等保留头。遗留的 `userAgent` 读取时迁入 `headers["User-Agent"]`。首次 OAuth 登录不收集请求头，登录后再编辑。覆盖 Anthropic OAuth 的 `claude-cli/…` 可能导致 Claude Pro/Max 拒绝请求。
-
 ### 命名端点预设
 
-这些行由添加提供商对话框的**服务**下拉框创建。命名服务的常见路径是服务 +
-API 密钥；自定义端点在常见路径上并排显示 API 密钥与接口格式。`vendorKey`
-使用 models.dev 提供商键。
+这些行由添加提供商对话框的**服务**下拉框创建，而不是来自一种新协议。它们
+仍然是 `type: "openai_compatible"`。常见路径是服务 + API key；已发布的主机
+以摘要形式展示，展示名称可在 Advanced 中编辑。自定义端点把名称显示在 Base URL
+旁边，再把 API key 显示在 API 格式旁边。`vendorKey` 使用 models.dev 的提供商键。
 
-国际：OpenAI、Anthropic、Google Gemini、OpenRouter、Groq、xAI、Mistral、
-Together、Fireworks、OpenCode Go、Z.AI。
+国际：OpenAI（`responses`）、Anthropic（`anthropic_messages`）、Google Gemini
+（`google_generative_ai`）、OpenRouter、Groq、xAI、Mistral、Together AI、
+Fireworks、OpenCode Go（`opencode_go`）、Z.AI / Z.AI Coding Plan。
 
-国内：DeepSeek、通义千问、月之暗面、智谱 / Coding Plan、硅基流动、火山方舟、
-MiniMax、Kimi 编程。
+国内：DeepSeek、通义千问 DashScope（`alibaba-cn`）、月之暗面
+（`moonshotai-cn`）、智谱 AI / Coding Plan、硅基流动（`siliconflow-cn`）、
+火山方舟、MiniMax（`anthropic_messages`）、Kimi For Coding
+（`anthropic_messages`）。
 
-智谱 / Z.AI 的 Completions 请求仍使用 `thinkingFormat: "zai"` 与
-`zaiToolStream: true`。
+智谱 / Z.AI 的 Completions 请求仍然会收到 `thinkingFormat: "zai"` 与
+`zaiToolStream: true`。pi-ai 的 `zai-coding-cn` 仍是 `zhipuai-coding-plan`
+的别名。
 
 ### 厂商账户预设
 
 这些行由登录创建（设置 → 模型配置 → 厂商账户），而不是由自定义提供商
 对话框创建。列表在运行时由 `models.getProviders().filter(p => p.auth.oauth)`
 派生，因此它跟随 pi-ai 而不是本表；`baseUrl`、`apiStyle` 与 `defaultModelId`
-在登录后由账户自己的目录填入。
+在登录后由该账户自己的目录填入。匹配的 models.dev 记录提供绑定元数据；
+快照中不存在的账户模型保持通用形态。
 
 | vendorKey | 订阅 | 典型 apiStyle | 登录形态 |
 |---|---|---|---|


### PR DESCRIPTION
## Problem

Companion to #116. `03-runtime/12-provider-config-schema.md` passes
`pnpm docs:check`, but the Chinese mirror is 140 lines shorter than the source
and, in the worst case, **tells the reader to write config values the app
cannot parse**.

The built-in vendor preset table translated its identifier columns:

| Chinese (before) | actual value |
|---|---|
| 人择的 | `anthropic` |
| 烟花 | `fireworks` |
| 基岩 | `bedrock` |
| 格罗克 | `groq` |
| 在一起 | `together` |
| 深度搜索 | `deepseek` |
| 开放性 | `openai` |
| openai_兼容 | `openai_compatible` |
| aws_sdk_默认 | `aws_sdk_default` |

`anthropic` had been rendered in its dictionary sense (人择的, "anthropic" as
in the anthropic principle). These are literal `vendorKey`, protocol and
`authKind` values.

## Change

Three commits, limited to
`docs/zh-CN/spec/03-runtime/12-provider-config-schema.md`:

**1. Add section 5 (Bundled models.dev snapshot).** It was missing entirely, so
every following section carried a number one lower than the source and the two
pages could not be read side by side. The `ModelCatalogCacheRecord` type had
also lost its `catalogSource` annotation, and section 4 carried a paragraph
about context resolution with no counterpart in the English section — it
restates a rule that belongs to section 2, where the source keeps it.

**2. Complete the provider record schema (section 2).** 88 lines against the
source's 205, short in both halves.

The JSON schema block had lost the entire `models` array — `id`,
`contextWindow`, `maxTokens`, `thinkingLevels`, `defaultThinkingLevel`,
`supportsImages`, `supportsDocuments`, `availableForSubagents` — plus
`opencode_go` in the `apiStyle` enum. It now matches the English block line
for line.

The prose carried 2 paragraphs against the source's 11. Missing: Anthropic
Messages `/v1` handling (which is what avoids a doubled `/v1/v1/messages`
route), the `compat.supportsDeveloperRole` default, the vendor account
editor's multi-model bindings and the per-login row rule, the `models` binding
array with legacy `defaultModelId` materialization, context resolution against
the 128,000 seed, `availableForSubagents` persistence, the `opencode_go`
preset, the `x-opencode-session` requirement, and the whole `headers` contract
including its reserved key list and the `userAgent` migration.

**3. Restore the vendor preset identifiers (section 3).** The table above, plus
two paragraphs duplicated from section 2 that the English section 3 does not
have, the named-endpoint list's missing `apiStyle` annotations, and the
`zai-coding-cn` alias.

## Impacted specs

`docs/zh-CN/spec/03-runtime/12-provider-config-schema.md` — Chinese mirror
only. The English source of truth is unchanged, per the english-first rule
(ADR 0009).

## E2E scenarios

None. Documentation-only change with no user-visible or protocol-visible
behavior change.

## Validation

```
headings  24 / 24     table rows  29 / 29     fenced blocks  8 / 8
heading-level sequence identical line for line
section 2 schema block: zero diff against the English block
```

Per section, paragraph-block count and list-item count both match for all 12
sections — the check that catches prose drift, which `check-locales.mjs`
cannot see.

CI skips `docs/**` via `paths-ignore`, so no workflow runs for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018QbLNtSBhb3NWzDyLJk6SR
