### PR TITLE
fix(plugins): show work panel view capability

### DIFF
--- a/apps/desktop/src/pages/PluginsPage.tsx
+++ b/apps/desktop/src/pages/PluginsPage.tsx
@@ -108,6 +108,7 @@ const PERMISSION_RISK: Record<string, RiskTier> = {
 /** Display order for capability badges: what it adds before what it runs. */
 const CAPABILITY_ORDER: PluginCapability[] = [
   "panel",
+  "views",
   "commands",
   "tools",
   "skills",

--- a/apps/desktop/test/plugin-services.test.mjs
+++ b/apps/desktop/test/plugin-services.test.mjs
@@ -429,3 +429,22 @@ test("the plugins page keeps capability and service chips in row details", () =>
     assert.match(enSrc, new RegExp(`${key}:`));
   }
 });
+
+test("capability badges include every declared plugin capability", () => {
+  const block = pluginsPageSrc.match(
+    /const CAPABILITY_ORDER: PluginCapability\[\] = \[([\s\S]*?)\];/,
+  )?.[1];
+  assert.ok(block, "capability badge order is missing");
+  const order = [...block.matchAll(/"([^"]+)"/g)].map((match) => match[1]);
+  assert.deepEqual(order, [
+    "panel",
+    "views",
+    "commands",
+    "tools",
+    "skills",
+    "themes",
+    "mcp",
+    "services",
+    "bus",
+  ]);
+});

--- a/docs/spec/07-plugins/01-plugin-system.md
+++ b/docs/spec/07-plugins/01-plugin-system.md
@@ -60,10 +60,11 @@ In one sentence:
 5. **Theme plugins**: ship a CSS file that overrides the design tokens
 
 ### Beyond the MVP scope (implemented)
-6. **MCP server plugins**: declare stdio or remote HTTP MCP servers whose tools
+6. **Work panel view plugins**: dock isolated HTML views in the app's work panel
+7. **MCP server plugins**: declare stdio or remote HTTP MCP servers whose tools
    join the agent's tool set
-7. **Background service plugins**: keep a supervised resident worker alive
-8. **Inter-plugin message bus**: publish/subscribe over declared topics
+8. **Background service plugins**: keep a supervised resident worker alive
+9. **Inter-plugin message bus**: publish/subscribe over declared topics
 
 ### Later
 - Billing / signed plugins


### PR DESCRIPTION
## Summary

- Add the missing `views` capability to the installed-plugin badge order.
- Add a regression assertion covering every declared plugin capability.
- Update the plugin system specification to list work panel view plugins as implemented.
- No export behavior is introduced.

## Validation

- `node --test apps/desktop/test/plugin-services.test.mjs apps/desktop/test/extensions-page.test.mjs`
- `pnpm --filter @pi-desktop/desktop typecheck`
- `git diff --check`