### PR TITLE
fix(linux): restore GNOME tray integration

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -45,7 +45,7 @@
     "@types/react-dom": "^19.2.4",
     "@vitejs/plugin-react": "^4.6.0",
     "dompurify": "^3.4.13",
-    "electron": "^43.4.0",
+    "electron": "^43.4.1",
     "electron-builder": "^26.15.3",
     "electron-vite": "^4.0.0",
     "i18next": "^26.3.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,8 +62,8 @@ importers:
         specifier: '>=3.4.13 <4'
         version: 3.4.13
       electron:
-        specifier: ^43.4.0
-        version: 43.4.0(supports-color@7.2.0)
+        specifier: ^43.4.1
+        version: 43.6.0(supports-color@7.2.0)
       electron-builder:
         specifier: ^26.15.3
         version: 26.15.3(electron-builder-squirrel-windows@26.15.3)(supports-color@7.2.0)
@@ -2217,8 +2217,8 @@ packages:
     resolution: {integrity: sha512-bO3y10YikuUwUuDUQRM4KfwNkKhnpVO7IPdbsrejwN9/AABJzzTQ4GeHwyzNSrVO+tEH3/Np255a3sVZpZDjvg==}
     engines: {node: '>=8.0.0'}
 
-  electron@43.4.0:
-    resolution: {integrity: sha512-3qxGF0CeQbiox5oWV1JlbWGQ1VerbmDhTFqW4sJ8h7uqTHniFYPObXJcDna0DMh32et0fFyKzz0YY8lJv3t5jg==}
+  electron@43.6.0:
+    resolution: {integrity: sha512-DqVKYV+FXheMSLTxcMQ+NCo78BDgpnToSyIzXctlUtbP3lRGEuoo1P+C2n/90rJ7TvHgzP0bpP9fbbXxp4noIg==}
     engines: {node: '>= 22.12.0'}
     hasBin: true
 
@@ -6137,7 +6137,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  electron@43.4.0(supports-color@7.2.0):
+  electron@43.6.0(supports-color@7.2.0):
     dependencies:
       '@electron-internal/extract-zip': 1.0.5
       '@electron/get': 5.1.0(supports-color@7.2.0)


### PR DESCRIPTION
## Summary

- require Electron 43.4.1 or newer so Linux uses the upstream StatusNotifierItem fix
- refresh the lockfile to Electron 43.6.0

## Why

Electron 43.3.0 through 43.4.0 regressed Linux StatusNotifierItem property access. On GNOME/Wayland with the AppIndicator extension, PI-Desktop registered its D-Bus service but the shell failed to read the basic properties, so the tray icon and menu did not appear. Electron fixed this in 43.4.1.

The current main branch already carries the lowercase `desktopName`/`syncDesktopName` alignment needed for GNOME/Wayland Dock grouping. This PR intentionally keeps the remaining fix limited to the Electron dependency and lockfile.

## Validation

- `node --test apps/desktop/test/development-branding.test.mjs apps/desktop/test/window-menu.test.mjs apps/desktop/test/close-behavior-tray.test.mjs`
- `git diff --check`