### PR TITLE
docs(release): state that macOS artifacts ship unsigned by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,8 +305,22 @@ Ubuntu 20.04, Debian 11, Fedora 35, and older releases cannot load the bundled h
 
 ### macOS
 
-The tagged-release workflow signs, notarizes, and staples macOS artifacts with
-Developer ID credentials before publication.
+Tagged releases publish macOS artifacts **unsigned by default**. The Release
+workflow signs, notarizes, and staples with Developer ID credentials only when a
+maintainer manually dispatches it with `sign_macos: true`; see the
+[release runbook](docs/spec/06-delivery/06-release-runbook.md).
+
+For an unsigned build, macOS may report that **PI-Desktop.app** is damaged and
+cannot be opened. Move the app to `/Applications`, then clear the quarantine
+attribute:
+
+```bash
+xattr -cr /Applications/PI-Desktop.app
+```
+
+Every DMG also ships `PI-Desktop-macOS-opening-help.txt` with the same steps.
+Use them only for an app obtained from a trusted PI-Desktop source; signed and
+notarized builds do not need this command.
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -305,7 +305,15 @@ Ubuntu 20.04、Debian 11、Fedora 35 及更旧的发行版无法加载自带的 
 
 ### macOS
 
-带标签发布工作流程会在发布前使用 Developer ID 凭据完成 macOS 工件的签名、公证和装订。
+带标签发布默认产出**未签名**的 macOS 工件。只有维护者以 `sign_macos: true` 手动触发 Release 工作流时，才会使用 Developer ID 凭据完成签名、公证和装订；详见[发布运行手册](docs/zh-CN/spec/06-delivery/06-release-runbook.md)。
+
+对未签名的构建，macOS 可能提示 **PI-Desktop.app** 已损坏、无法打开。把应用移动到 `/Applications`，再清除隔离属性：
+
+```bash
+xattr -cr /Applications/PI-Desktop.app
+```
+
+每个 DMG 也附带写有相同步骤的 `PI-Desktop-macOS-opening-help.txt`。仅对你从可信 PI-Desktop 来源获取的应用使用该命令；已签名并公证的构建不需要它。
 
 ---
 


### PR DESCRIPTION
## What this fixes

`README.md` and `README.zh-CN.md` currently tell macOS users:

> The tagged-release workflow signs, notarizes, and staples macOS artifacts with Developer ID credentials before publication.

The published artifacts are not signed, and the READMEs no longer tell users how to open one.

## Evidence

**1. The workflow takes the unsigned lane on every tag push.**

`.github/workflows/release.yml` gates signing on `inputs.sign_macos == true`, and `sign_macos` is a `workflow_dispatch` input with `default: false`. A tag push supplies no inputs, so `inputs.sign_macos != true` holds and the unsigned lane runs with `CSC_IDENTITY_AUTO_DISCOVERY: 'false'`. The `Staple macOS installer ticket` and `Verify signed and notarized macOS installer` steps carry the same `sign_macos == true` condition, so neither ran.

**2. The repository's own release runbook already says so.**

`docs/spec/06-delivery/06-release-runbook.md`:

> **Default macOS release policy:** the GitHub Release workflow packages macOS DMG/ZIP artifacts unsigned by default. Tag pushes and manual runs with `sign_macos` omitted or set to `false` disable identity discovery, do not receive signing or notarization secrets, and skip macOS stapling and signature verification.

**3. The v0.14.4 changelog records the change.**

`packages/shared/src/changelog.ts`:

> Make macOS signing and notarization explicit opt-in, with opening guidance for trusted unsigned builds.

`docs/spec/01-product/01-product-scope.md` likewise lists both macOS targets as "signing/notarization remains credential-gated".

**4. Measured against the published v0.14.5 artifact.**

Downloaded `PI-Desktop-0.14.5-arm64.dmg` from the release; its sha512 matched `latest-mac.yml`. Mounted and inspected:

```
$ codesign -dv --verbose=4 PI-Desktop.app
Identifier=Electron
Format=app bundle with Mach-O thin (arm64)
CodeDirectory v=20400 size=392 flags=0x20002(adhoc,linker-signed)
Signature=adhoc
TeamIdentifier=not set
Info.plist=not bound

$ codesign --verify --deep --strict PI-Desktop.app
PI-Desktop.app: code has no resources but signature indicates they must be present
```

No `Authority=Developer ID Application`, no notarization ticket. `Resources/bin/pi-desktop-host-core` is ad-hoc signed as well.

**5. The shipping DMG contradicts the README.**

`apps/desktop/PI-Desktop-macOS-opening-help.txt` is bundled into the DMG, opens with "for this unsigned build", and gives the `xattr -cr` steps. The artifact tells users the build is unsigned while the README tells them it is signed and stapled.

## How this happened

`4f4f285` (*docs(release): align macOS signing guidance*) replaced the previous README text — which correctly said "macOS builds are not yet code-signed or notarized" and documented the `xattr -cr` workaround — with the signed-and-stapled claim. That commit did align the spec mirrors and the runbook, and those are accurate; the two READMEs are the only surfaces left asserting the old behavior.

`AGENTS.md` treats READMEs as release surfaces:

> When a release changes user-visible behavior, refresh the affected Highlights, Download, Getting started, Status, or Development claims in both locales.

0.14.4 changed exactly this behavior, so this completes that refresh.

## What changes

Both READMEs' `### macOS` sections only (+25/-3):

- state the unsigned-by-default policy and name the `sign_macos: true` opt-in
- restore the `xattr -cr /Applications/PI-Desktop.app` opening guidance
- point at the DMG's bundled help file and the release runbook

No code, workflow, or spec changes. `docs/spec/` already describes both lanes correctly, so there is nothing to sync there. English is edited as the source of truth and `README.zh-CN.md` mirrors it, linking the `docs/zh-CN/` runbook.

## Validation

- Both runbook link targets exist in their respective locales.
- `docs/scripts/check-locales.mjs` reports the same three pre-existing notices as on `main` (`03-runtime/08-error-codes.md`, `04-ux/08-component-spec.md`, `08-meta/decisions-log.md`). READMEs are outside its scope.
- The app installs and boots from the unsigned artifact once quarantine is cleared — the exact flow the restored text documents. Verified end to end on macOS arm64: host-core handshake, agent sidecar ready, plugins restored, `window-shown`, no error or warn log lines.

If the intent is instead to publish signed artifacts from tag builds, the fix belongs in `release.yml` (running the signed lane on tags) rather than in the READMEs — happy to close this in favour of that.
