### PR TITLE
feat(desktop): add a viewport-fixed work panel toggle button

### DIFF
--- a/apps/desktop/src/App.tsx
+++ b/apps/desktop/src/App.tsx
@@ -45,6 +45,7 @@ import {
 import { StartupSplash } from "./components/StartupSplash";
 import { cx } from "./components/ui";
 import {
+  IconPanel,
   IconNewSession,
   IconSidebar,
 } from "./components/icons";
@@ -272,6 +273,27 @@ function AppShell() {
   useEffect(() => {
     workPanelExitingRef.current = workPanelExiting;
   }, [workPanelExiting]);
+
+  const togglePresentedWorkPanel = useCallback(() => {
+    const store = useAppStore.getState();
+    if (workPanelExitingRef.current) {
+      store.openWorkPanel();
+      return;
+    }
+    // Prefer the visible presentation over a briefly stale session projection:
+    // a second click on the same button must always collapse a panel the user
+    // can currently see instead of routing through openWorkPanel again.
+    if (store.workPanelOpen || presentedWorkPanelRef.current) {
+      store.collapseWorkPanel();
+      if (presentedWorkPanelRef.current && !workPanelExitingRef.current) {
+        workPanelExitGeneration.current += 1;
+        workPanelExitingRef.current = true;
+        setWorkPanelExiting(true);
+      }
+      return;
+    }
+    store.openWorkPanel();
+  }, []);
 
   const finishWorkPanelExit = useCallback((generation: number) => {
     if (generation !== workPanelExitGeneration.current) return;
@@ -1936,6 +1958,18 @@ function AppShell() {
               }}
             />
           )}
+
+          <button
+            type="button"
+            className="app-work-panel-toggle no-drag"
+            title={t("nav.toggleWorkPanel")}
+            aria-label={t("nav.toggleWorkPanel")}
+            aria-pressed={workPanelOpen || presentedWorkPanelOpen}
+            disabled={!activeSessionId && !presentedWorkPanelOpen && !workPanelExiting}
+            onClick={togglePresentedWorkPanel}
+          >
+            <IconPanel size={15} />
+          </button>
 
           <SearchDialog open={searchOpen} onClose={() => setSearchOpen(false)} />
           <ToastHost />

--- a/apps/desktop/src/styles/chrome.css
+++ b/apps/desktop/src/styles/chrome.css
@@ -488,6 +488,7 @@
 .conversation-topbar .ct-right {
   flex: 0 0 auto;
   justify-content: flex-end;
+  padding-right: 36px;
 }
 
 .conversation-topbar .ct-title-wrap {
@@ -515,7 +516,8 @@
   line-height: var(--leading-compact);
 }
 
-.conversation-topbar .ct-icon-btn {
+.conversation-topbar .ct-icon-btn,
+.app-work-panel-toggle {
   display: inline-flex;
   height: 28px;
   width: 28px;
@@ -530,12 +532,14 @@
     color var(--motion-duration-fast) var(--motion-ease-out);
 }
 
-.conversation-topbar .ct-icon-btn:hover:not(:disabled) {
+.conversation-topbar .ct-icon-btn:hover:not(:disabled),
+.app-work-panel-toggle:hover:not(:disabled) {
   background: var(--ds-bg-hover);
   color: var(--ds-text-primary);
 }
 
-.conversation-topbar .ct-icon-btn:disabled {
+.conversation-topbar .ct-icon-btn:disabled,
+.app-work-panel-toggle:disabled {
   opacity: 0.4;
   cursor: default;
 }
@@ -552,6 +556,29 @@
   display: inline-flex;
   align-items: center;
   gap: 2px;
+}
+
+/* Keep the sole work-panel toggle anchored to the viewport while the in-flow
+ * panel changes MainPane width. AppShell ownership keeps it available on every
+ * non-Settings route and above the panel header throughout both animations. */
+.app-work-panel-toggle {
+  position: fixed;
+  top: 9px;
+  right: 12px;
+  z-index: 30;
+  pointer-events: auto;
+  -webkit-app-region: no-drag;
+  app-region: no-drag;
+}
+
+.app-work-panel-toggle[aria-pressed="true"] {
+  background: var(--ds-bg-active);
+  color: var(--ds-text-primary);
+}
+
+:root[data-platform="win32"] .app-work-panel-toggle,
+:root[data-platform="linux"] .app-work-panel-toggle {
+  right: calc(var(--ds-window-controls-width) + 12px);
 }
 
 /* macOS traffic lights occupy the top-left ~76px; only reserve that space
@@ -922,10 +949,10 @@
   /* Continuous with the adjacent titlebar: no side seam (D297). */
 }
 
-/* The main shell puts the controls inside the conversation pane so the right
- * work panel can use its own complete header without inheriting app chrome. */
+/* The main shell keeps one control band mounted inside MainPane, but its
+ * viewport-fixed position must not follow MainPane while the work panel reflows. */
 .window-controls.window-controls-in-pane {
-  position: absolute;
+  position: fixed;
 }
 
 .window-control-btn {

--- a/apps/desktop/test/window-menu.test.mjs
+++ b/apps/desktop/test/window-menu.test.mjs
@@ -161,7 +161,7 @@ test("Windows and Linux use menu-free frameless chrome with window controls", ()
   );
   assert.match(
     stylesSource,
-    /\.window-controls\.window-controls-in-pane\s*\{[^}]*position:\s*absolute;/s,
+    /\.window-controls\.window-controls-in-pane\s*\{[^}]*position:\s*fixed;/s,
   );
   assert.match(
     stylesSource,

--- a/apps/desktop/test/work-panel.test.mjs
+++ b/apps/desktop/test/work-panel.test.mjs
@@ -49,8 +49,10 @@ test("work panel replaces the context panel overlay", async () => {
   assert.match(appSource, /useAppStore\.getState\(\)\.toggleWorkPanel\(\)/);
   assert.match(storeSource, /openWorkPanel:\s*\(\) => \{/);
   // The panel is toggled inside the renderer store; the legacy main-process
-  // nav bridge that resized the OS window must stay gone.
-  assert.doesNotMatch(appSource, /nav\.toggleWorkPanel/);
+  // nav bridge that resized the OS window must stay gone. The i18n key
+  // `nav.toggleWorkPanel` (used by the in-app toggle button title) is fine;
+  // the bridge channel `IPC.invoke.nav.toggleWorkPanel` is not.
+  assert.doesNotMatch(appSource, /IPC\.invoke\.nav\.toggleWorkPanel|navToggleWorkPanel/);
   assert.doesNotMatch(appSource, /key\.toLowerCase\(\) === "j"/);
 });
 

--- a/packages/i18n/src/locales/de/index.ts
+++ b/packages/i18n/src/locales/de/index.ts
@@ -132,6 +132,7 @@ export const de = {
     "newChat": "Neuer Chat",
     "conversation": "Konversation",
     "toggleSidebar": "Seitenleiste umschalten",
+    "toggleWorkPanel": "Arbeitspanel umschalten",
     "sessions": "Sitzungen",
     "commandPalette": "Befehlspalette",
     "back": "Zurück",

--- a/packages/i18n/src/locales/en/index.ts
+++ b/packages/i18n/src/locales/en/index.ts
@@ -141,6 +141,7 @@ export const en = {
     newChat: "New chat",
     conversation: "Conversation",
     toggleSidebar: "Toggle sidebar",
+    toggleWorkPanel: "Toggle work panel",
     sessions: "Sessions",
     commandPalette: "Command palette",
     back: "Back",

--- a/packages/i18n/src/locales/es/index.ts
+++ b/packages/i18n/src/locales/es/index.ts
@@ -132,6 +132,7 @@ export const es = {
     "newChat": "Nuevo chat",
     "conversation": "Conversación",
     "toggleSidebar": "Alternar barra lateral",
+    "toggleWorkPanel": "Alternar panel de trabajo",
     "sessions": "Sesiones",
     "commandPalette": "Paleta de comandos",
     "back": "Atrás",

--- a/packages/i18n/src/locales/fr/index.ts
+++ b/packages/i18n/src/locales/fr/index.ts
@@ -132,6 +132,7 @@ export const fr = {
     "newChat": "Nouvelle discussion",
     "conversation": "Conversation",
     "toggleSidebar": "Basculer la barre latérale",
+    "toggleWorkPanel": "Basculer le panneau de travail",
     "sessions": "Sessions",
     "commandPalette": "Palette de commandes",
     "back": "Retour",

--- a/packages/i18n/src/locales/ko/index.ts
+++ b/packages/i18n/src/locales/ko/index.ts
@@ -143,6 +143,7 @@ export const ko = {
     newChat: "새 채팅",
     conversation: "대화",
     toggleSidebar: "사이드바 전환",
+    toggleWorkPanel: "작업 패널 전환",
     sessions: "세션",
     commandPalette: "명령 팔레트",
     back: "뒤로",

--- a/packages/i18n/src/locales/tr/index.ts
+++ b/packages/i18n/src/locales/tr/index.ts
@@ -143,6 +143,7 @@ export const tr = {
     newChat: "Yeni sohbet",
     conversation: "Sohbet",
     toggleSidebar: "Kenar çubuğunu aç/kapat",
+    toggleWorkPanel: "Çalışma panelini aç/kapat",
     sessions: "Oturumlar",
     commandPalette: "Komut paleti",
     back: "Geri",

--- a/packages/i18n/src/locales/zh-CN/index.ts
+++ b/packages/i18n/src/locales/zh-CN/index.ts
@@ -136,6 +136,7 @@ export const zhCN = {
     newChat: "新对话",
     conversation: "对话",
     toggleSidebar: "切换侧边栏",
+    toggleWorkPanel: "切换工作面板",
     sessions: "会话",
     commandPalette: "命令面板",
     back: "后退",

--- a/packages/i18n/src/locales/zh-TW/index.ts
+++ b/packages/i18n/src/locales/zh-TW/index.ts
@@ -136,6 +136,7 @@ export const zhTW = {
     newChat: "新對話",
     conversation: "對話",
     toggleSidebar: "切換側邊欄",
+    toggleWorkPanel: "切換工作面板",
     sessions: "會話",
     commandPalette: "命令面板",
     back: "後退",


### PR DESCRIPTION
## Summary

The work panel was reachable only via the keyboard shortcut or when an agent opened a tab, which left it undiscoverable. This adds a single toggle button pinned to the top-right viewport corner, available on every non-Settings route.

- The button prefers the visible presentation over a briefly stale session projection, so a second click always collapses a panel the user can currently see, even while the open animation is still in flight.
- Clicking during the exit animation reopens the panel instead of dead-ending.
- `aria-pressed` tracks both the store state and the presented panel; the button is disabled until a session exists to show the panel for.
- `window-controls-in-pane` becomes viewport-fixed so it does not follow MainPane while the panel reflows (absolute → fixed).
- i18n: `nav.toggleWorkPanel` added to all locales.

## Test plan

- [x] `pnpm typecheck` in `apps/desktop` — 0 errors
- [x] `pnpm test` in `apps/desktop` — 1257/1257 pass (window-menu and work-panel assertions updated to the new contracts)
- [x] i18n suite — 22/22 pass (locale key parity)