### PR TITLE
feat(host-core): support PowerShell 7 as a selectable Windows command shell

### DIFF
--- a/crates/host-core/src/tools/shell.rs
+++ b/crates/host-core/src/tools/shell.rs
@@ -19,12 +19,22 @@ use std::sync::OnceLock;
 use std::time::Duration;
 
 pub const WINDOWS_POWERSHELL_ID: &str = "windows-powershell";
+/// PowerShell 7+ (`pwsh.exe`). It installs side by side with, and is not
+/// replaced by, the in-box Windows PowerShell 5.1 that
+/// [`WINDOWS_POWERSHELL_ID`] resolves to, so it needs its own catalog entry.
+pub const PWSH_ID: &str = "windows-pwsh";
 pub const CMD_ID: &str = "cmd";
 pub const GIT_BASH_ID: &str = "git-bash";
 pub const BASH_ID: &str = "bash";
 
 pub const SHELL_MISSING_GUIDANCE: &str =
     "No usable command shell was found. Install or enable a supported shell and try again.";
+
+/// Guidance for a selected but absent PowerShell 7. It names the locations the
+/// resolver searched so the user can fix the install or PATH instead of
+/// guessing why the choice is unavailable.
+pub const PWSH_MISSING_GUIDANCE: &str =
+    "PowerShell 7 (pwsh.exe) was not found. Install PowerShell 7, or add its install directory to PATH. Searched %ProgramFiles%\\PowerShell\\7\\pwsh.exe, then pwsh.exe on PATH.";
 
 /// Windows CreateProcess accepts at most 32,767 UTF-16 code units in its
 /// command line. Keep the builder below that limit, including executable and
@@ -83,12 +93,17 @@ pub fn default_shell_id() -> &'static str {
 }
 
 pub fn is_known_shell_id(id: &str) -> bool {
-    matches!(id, WINDOWS_POWERSHELL_ID | CMD_ID | GIT_BASH_ID | BASH_ID)
+    matches!(
+        id,
+        WINDOWS_POWERSHELL_ID | PWSH_ID | CMD_ID | GIT_BASH_ID | BASH_ID
+    )
 }
 
 pub fn dialect_for_id(id: &str) -> Option<&'static str> {
     match id {
-        WINDOWS_POWERSHELL_ID => Some("powershell"),
+        // Both PowerShell generations share one invocation contract, so the
+        // dialect stays `powershell` while the pinned ID keeps them distinct.
+        WINDOWS_POWERSHELL_ID | PWSH_ID => Some("powershell"),
         CMD_ID => Some("cmd"),
         GIT_BASH_ID | BASH_ID => Some("posix"),
         _ => None,
@@ -153,6 +168,7 @@ pub fn resolve_shell_for_platform(
             WINDOWS_POWERSHELL_ID => {
                 find_windows_powershell().map(|program| ResolvedShell { program })
             }
+            PWSH_ID => find_pwsh().map(|program| ResolvedShell { program }),
             CMD_ID => find_cmd().map(|program| ResolvedShell { program }),
             GIT_BASH_ID => find_bash().map(|program| ResolvedShell { program }),
             _ => Err(format!("command shell '{id}' is not available on Windows")),
@@ -179,7 +195,9 @@ pub fn build_invocation_for_platform(
 
     let args = match platform {
         ShellPlatform::Windows => match shell_id {
-            WINDOWS_POWERSHELL_ID => {
+            // PowerShell 7 keeps the PowerShell 5.1 invocation contract, so the
+            // same non-interactive script drives both generations.
+            WINDOWS_POWERSHELL_ID | PWSH_ID => {
                 let script = format!(
                     "$OutputEncoding = New-Object System.Text.UTF8Encoding($false); [Console]::OutputEncoding = $OutputEncoding; $ErrorActionPreference = 'Continue'; $ProgressPreference = 'SilentlyContinue'; $global:LASTEXITCODE = 0; $script:piPowerShellError = $false; & {{ {command} }} 2>&1 | ForEach-Object {{ if ($_ -is [System.Management.Automation.ErrorRecord]) {{ $script:piPowerShellError = $true; [Console]::Error.WriteLine($_.Exception.Message) }} else {{ [Console]::Out.WriteLine([string]$_) }} }}; $piNativeExitCode = $LASTEXITCODE; if ($script:piPowerShellError) {{ exit 1 }}; exit $piNativeExitCode"
                 );
@@ -258,6 +276,13 @@ fn choices_for_platform(platform: ShellPlatform) -> Vec<ShellOption> {
                 dialect: "powershell".into(),
                 available: false,
                 is_default: true,
+            },
+            ShellOption {
+                id: PWSH_ID.into(),
+                label: "PowerShell 7".into(),
+                dialect: "powershell".into(),
+                available: false,
+                is_default: false,
             },
             ShellOption {
                 id: CMD_ID.into(),
@@ -370,6 +395,34 @@ fn find_windows_powershell() -> Result<PathBuf, String> {
 #[cfg(not(windows))]
 fn find_windows_powershell() -> Result<PathBuf, String> {
     Err("Windows PowerShell is not available on this platform".into())
+}
+
+/// Resolve PowerShell 7. A machine-scope install (MSI, `winget --scope
+/// machine`) lands in `%ProgramFiles%\PowerShell\7`; Store, user-scope, and
+/// portable installs surface through a PATH entry instead (the `WindowsApps`
+/// execution alias or the extracted folder). Both are probed in that order and
+/// failure names both, because neither location is discoverable by guessing.
+#[cfg(windows)]
+fn find_pwsh() -> Result<PathBuf, String> {
+    // `ProgramW6432` covers a 32-bit host process on 64-bit Windows, where
+    // `ProgramFiles` points at the x86 tree instead.
+    for base in ["ProgramFiles", "ProgramW6432"] {
+        if let Some(root) = env::var_os(base) {
+            let candidate = PathBuf::from(root)
+                .join("PowerShell")
+                .join("7")
+                .join("pwsh.exe");
+            if is_executable(&candidate) {
+                return Ok(candidate);
+            }
+        }
+    }
+    search_path("pwsh.exe", |_| true).ok_or_else(|| PWSH_MISSING_GUIDANCE.to_string())
+}
+
+#[cfg(not(windows))]
+fn find_pwsh() -> Result<PathBuf, String> {
+    Err("PowerShell 7 is not available on this platform".into())
 }
 
 #[cfg(windows)]
@@ -540,19 +593,41 @@ mod tests {
 
         let windows = catalog_for_platform(ShellPlatform::Windows, None, |_| true);
         assert_eq!(windows.configured_id, WINDOWS_POWERSHELL_ID);
-        assert_eq!(windows.choices.len(), 3);
+        assert_eq!(windows.choices.len(), 4);
         assert_eq!(windows.choices[0].label, "Windows PowerShell");
         assert!(windows.choices[0].is_default);
+        assert_eq!(windows.choices[1].id, PWSH_ID);
+        assert_eq!(windows.choices[1].label, "PowerShell 7");
+        assert_eq!(windows.choices[1].dialect, "powershell");
+        assert!(!windows.choices[1].is_default);
 
+        // The fallback follows catalog order, so PowerShell 7 — placed directly
+        // after the in-box 5.1 entry — is the first available choice once 5.1 is
+        // gone. Both entries keep the `powershell` dialect, so the fallback
+        // cannot change the command language a pinned turn runs.
         let fallback =
             catalog_for_platform(ShellPlatform::Windows, Some(WINDOWS_POWERSHELL_ID), |id| {
                 id != WINDOWS_POWERSHELL_ID
             });
         assert_eq!(
             fallback.effective.as_ref().map(|option| option.id.as_str()),
-            Some(CMD_ID)
+            Some(PWSH_ID)
         );
         assert!(fallback.fallback);
+
+        // With both PowerShell entries gone, `cmd` comes next in catalog order.
+        let cmd_fallback =
+            catalog_for_platform(ShellPlatform::Windows, Some(WINDOWS_POWERSHELL_ID), |id| {
+                id == CMD_ID || id == GIT_BASH_ID
+            });
+        assert_eq!(
+            cmd_fallback
+                .effective
+                .as_ref()
+                .map(|option| option.id.as_str()),
+            Some(CMD_ID)
+        );
+        assert!(cmd_fallback.fallback);
     }
 
     #[test]
@@ -585,6 +660,84 @@ mod tests {
         let plain = dir.path().join("not-a-shell");
         std::fs::write(&plain, "text").unwrap();
         assert!(!is_executable(&plain));
+    }
+
+    #[test]
+    fn powershell_7_is_a_distinct_selection_with_the_powershell_contract() {
+        // The 5.1 and 7 entries stay separately selectable while sharing one
+        // dialect and one non-interactive script.
+        assert!(is_known_shell_id(PWSH_ID));
+        assert_eq!(dialect_for_id(PWSH_ID), Some("powershell"));
+        assert_ne!(PWSH_ID, WINDOWS_POWERSHELL_ID);
+
+        let selected = catalog_for_platform(ShellPlatform::Windows, Some(PWSH_ID), |id| {
+            id != WINDOWS_POWERSHELL_ID
+        });
+        assert_eq!(selected.configured_id, PWSH_ID);
+        assert!(!selected.fallback);
+        assert_eq!(
+            selected.effective.as_ref().map(|option| option.id.as_str()),
+            Some(PWSH_ID)
+        );
+
+        let pwsh = build_invocation_for_platform(
+            ShellPlatform::Windows,
+            PWSH_ID,
+            PathBuf::from("pwsh.exe"),
+            "Write-Output 'hello'",
+        )
+        .unwrap();
+        let legacy = build_invocation_for_platform(
+            ShellPlatform::Windows,
+            WINDOWS_POWERSHELL_ID,
+            PathBuf::from("powershell.exe"),
+            "Write-Output 'hello'",
+        )
+        .unwrap();
+        assert_eq!(pwsh.args, legacy.args);
+        assert_eq!(pwsh.args[7], "-Command");
+        assert!(pwsh.args[8].contains("Write-Output 'hello'"));
+    }
+
+    #[test]
+    fn unavailable_powershell_7_falls_back_and_reports_it() {
+        let catalog = catalog_for_platform(ShellPlatform::Windows, Some(PWSH_ID), |id| {
+            id != PWSH_ID
+        });
+        assert_eq!(catalog.configured_id, PWSH_ID);
+        assert_eq!(
+            catalog.effective.as_ref().map(|option| option.id.as_str()),
+            Some(WINDOWS_POWERSHELL_ID)
+        );
+        assert!(catalog.fallback);
+    }
+
+    #[test]
+    fn missing_powershell_7_guidance_names_the_searched_locations() {
+        // "was not found" alone leaves the user unable to act; the message has
+        // to name both probed locations.
+        assert!(PWSH_MISSING_GUIDANCE.contains("pwsh.exe"));
+        assert!(PWSH_MISSING_GUIDANCE.contains("ProgramFiles"));
+        assert!(PWSH_MISSING_GUIDANCE.contains("PATH"));
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn powershell_7_resolves_only_through_its_own_locations() {
+        // Guards the resolver contract without depending on whether this
+        // machine has PowerShell 7 installed: either it resolves to a real
+        // `pwsh.exe`, or it fails with the guidance that names the locations.
+        match resolve_shell(PWSH_ID) {
+            Ok(resolved) => assert_eq!(
+                resolved
+                    .program
+                    .file_name()
+                    .and_then(|name| name.to_str())
+                    .map(str::to_ascii_lowercase),
+                Some("pwsh.exe".to_string())
+            ),
+            Err(message) => assert_eq!(message, PWSH_MISSING_GUIDANCE),
+        }
     }
 
     #[test]

--- a/docs/adr/0054-selectable-command-shell-catalog.md
+++ b/docs/adr/0054-selectable-command-shell-catalog.md
@@ -1,6 +1,6 @@
 # ADR 0054: Selectable command shell catalog and execution identity
 
-- Status: Accepted for implementation (timeout bounds in §4 amended by ADR 0167 / D329; the PowerShell 7 entry is added by ADR 0209 / D380)
+- Status: Accepted for implementation (timeout bounds in §4 amended by ADR 0167 / D329; the PowerShell 7 entry is added by ADR 0209 / D381)
 - Date: 2026-07-31
 - Baseline: `0.4.14`
 - Protocol: v9

--- a/docs/adr/0054-selectable-command-shell-catalog.md
+++ b/docs/adr/0054-selectable-command-shell-catalog.md
@@ -1,6 +1,6 @@
 # ADR 0054: Selectable command shell catalog and execution identity
 
-- Status: Accepted for implementation (timeout bounds in §4 amended by ADR 0167 / D329)
+- Status: Accepted for implementation (timeout bounds in §4 amended by ADR 0167 / D329; the PowerShell 7 entry is added by ADR 0209 / D380)
 - Date: 2026-07-31
 - Baseline: `0.4.14`
 - Protocol: v9
@@ -22,14 +22,17 @@ Host-core exposes a platform-aware catalog with stable IDs:
 
 | ID | Shell | Discovery |
 |---|---|---|
-| `windows-powershell` | native PowerShell | `powershell.exe`/native PowerShell on Windows |
+| `windows-powershell` | in-box Windows PowerShell 5.1 | `powershell.exe`/native PowerShell on Windows |
+| `windows-pwsh` | PowerShell 7+ (side-by-side install) | `pwsh.exe` under `%ProgramFiles%\PowerShell\7` or on PATH |
 | `cmd` | Windows Command Prompt | `cmd.exe` on Windows |
 | `git-bash` | Git for Windows Bash | Git for Windows installation and PATH |
 | `bash` | Unix Bash | `/bin/bash`, `/usr/bin/bash`, or an approved PATH entry on macOS/Linux |
 
-The Windows catalog contains `windows-powershell`, `cmd`, and `git-bash`; the
-Unix catalog contains `bash`. The catalog does not accept an arbitrary
-renderer- or sidecar-supplied executable path.
+The Windows catalog contains `windows-powershell`, `windows-pwsh`, `cmd`, and
+`git-bash`; the Unix catalog contains `bash`. The catalog does not accept an
+arbitrary renderer- or sidecar-supplied executable path. Windows PowerShell 5.1
+stays the platform default; `windows-pwsh` is selectable but never selected
+implicitly, so choosing it cannot change an existing user's shell by surprise.
 
 Settings writes accept only an available ID for the current platform. Unknown,
 unavailable, and wrong-platform IDs are rejected. If a persisted ID later

--- a/docs/adr/0209-powershell-7-selectable-windows-shell.md
+++ b/docs/adr/0209-powershell-7-selectable-windows-shell.md
@@ -5,7 +5,7 @@
 - Baseline: `0.14.6`
 - Protocol: v9
 - Storage schema: v10
-- Decision: D380
+- Decision: D381
 - Amends: ADR 0054 §1 (Windows catalog table and Windows catalog list)
 - Related: [03-runtime/03-tools-and-permissions.md](../spec/03-runtime/03-tools-and-permissions.md),
   [03-runtime/01-ipc-protocol.md](../spec/03-runtime/01-ipc-protocol.md),

--- a/docs/adr/0209-powershell-7-selectable-windows-shell.md
+++ b/docs/adr/0209-powershell-7-selectable-windows-shell.md
@@ -1,0 +1,117 @@
+# ADR 0209: PowerShell 7 as a selectable Windows command shell
+
+- Status: Proposed (issue #151); the maintainer sets the final status on merge
+- Date: 2026-09-10
+- Baseline: `0.14.6`
+- Protocol: v9
+- Storage schema: v10
+- Decision: D380
+- Amends: ADR 0054 §1 (Windows catalog table and Windows catalog list)
+- Related: [03-runtime/03-tools-and-permissions.md](../spec/03-runtime/03-tools-and-permissions.md),
+  [03-runtime/01-ipc-protocol.md](../spec/03-runtime/01-ipc-protocol.md),
+  [03-runtime/06-host-rpc-protocol.md](../spec/03-runtime/06-host-rpc-protocol.md),
+  [04-ux/06-settings-ia.md](../spec/04-ux/06-settings-ia.md),
+  [05-security/01-security.md](../spec/05-security/01-security.md),
+  [06-delivery/04-e2e-test-plan.md](../spec/06-delivery/04-e2e-test-plan.md) (E2E-112)
+
+## Context
+
+ADR 0054 froze a Windows catalog of `windows-powershell`, `cmd`, and `git-bash`.
+The `windows-powershell` entry resolves the in-box Windows PowerShell 5.1
+(`%SystemRoot%\System32\WindowsPowerShell\v1.0\powershell.exe`).
+
+PowerShell 7 (`pwsh.exe`) is a separate product that installs side by side with
+5.1 and never replaces it. A user who wants PowerShell 7 therefore had no way to
+select it: the catalog exposed no entry, and `Bash` kept launching 5.1 even after
+the user installed 7. Issue #151 reports exactly that, and the codebase confirms
+the gap — `crates/host-core/src/tools/shell.rs` contains no `pwsh.exe`
+resolution path, and `packages/shared/src/command-shells.ts` lists four stable
+IDs only.
+
+## Decision
+
+### 1. A fifth stable ID: `windows-pwsh`
+
+The Windows catalog gains `windows-pwsh` (`PowerShell 7`), selectable from
+Settings and persisted in `defaultCommandShell` like every other entry. The ID is
+stable and platform-scoped, and joins the `CommandShellId` protocol union.
+
+### 2. Resolution order and failure guidance
+
+`windows-pwsh` resolves, in order:
+
+1. `%ProgramFiles%\PowerShell\7\pwsh.exe`, which is where a machine-scope MSI or
+   `winget --scope machine` install lands. `%ProgramW6432%` is probed as well,
+   so a 32-bit host process on 64-bit Windows — where `ProgramFiles` points at
+   the x86 tree — still finds a real 64-bit install.
+2. `pwsh.exe` on PATH, which covers Store, user-scope, and portable installs.
+
+Neither location is discoverable by guessing, so a miss returns
+`SHELL_NOT_FOUND` with guidance that names both searched locations and points at
+installing PowerShell 7. The wording lives in `PWSH_MISSING_GUIDANCE` next to the
+resolver.
+
+### 3. One shared invocation contract
+
+PowerShell 7 accepts the same non-interactive flags as 5.1 (`-NoLogo
+-NoProfile -NonInteractive -InputFormat Text -OutputFormat Text -Command`), so
+both IDs keep the `powershell` dialect and share the existing pinned script,
+including the UTF-8 output setup and `$LASTEXITCODE` propagation. The catalog ID
+stays distinct so the pinned turn identity, the folded settings write path, and
+`COMMAND_SHELL_CHANGED` still compare exactly.
+
+### 4. The platform default does not change
+
+`windows-powershell` remains the default for a fresh Windows install, keeps
+`is_default`, and stays the value `defaultCommandShell` falls back to when unset.
+PowerShell 7 is never chosen for a user who did not ask for it: selecting it is an
+explicit Settings action.
+
+Catalog order still decides the first-available fallback (ADR 0054 §1), and
+`windows-pwsh` sits directly after the in-box entry, so a persisted
+`windows-powershell` that later becomes unavailable now resolves to
+`windows-pwsh` before `cmd`. This follows the existing fallback rule instead of
+adding a new one, and it cannot change the command language — both entries share
+the `powershell` dialect. On Windows the in-box 5.1 entry is effectively always
+present, so the reordering is not reachable for a normal install; the catalog
+test covers both steps of the order so the behavior is pinned either way.
+
+## Consequences
+
+- Windows users can run agent commands under PowerShell 7 while keeping 5.1
+  available as a separate, still-default choice.
+- The protocol gains one ID, so the folded settings validation, the catalog
+  E2E lane (E2E-112), `scripts/e2e-plan.mjs`, and the protocol type unions move
+  with it. No new RPC method, no new tool name, and no storage migration are
+  needed: an unknown ID is rejected exactly as before, and a persisted
+  unavailable `windows-pwsh` recovers through the first-available fallback.
+- One existing behavior moves: a persisted `windows-powershell` that becomes
+  unavailable now falls back to `windows-pwsh` instead of `cmd`, because the new
+  entry sits earlier in catalog order. The dialect is unchanged, and the case is
+  unreachable on a normal Windows install, but the existing catalog test is
+  updated to pin both steps of the order rather than only its first result.
+- A machine without PowerShell 7 keeps the entry visible and unavailable, the
+  same presentation `git-bash` already uses.
+
+## Alternatives rejected
+
+### Make `windows-powershell` prefer `pwsh.exe` when present
+
+Rejected: it silently changes the shell an existing user already runs, and it
+makes the pinned turn identity ambiguous between two different executables that
+share a dialect. It also cannot express "use 5.1" once 7 is installed, which is
+the choice ADR 0054 §1 deliberately granted by freezing the catalog.
+
+### Let the user configure an arbitrary `pwsh.exe` path
+
+Rejected: ADR 0054 already rejected renderer- or sidecar-supplied executable
+paths, because catalog policy and identity validation depend on a closed ID set.
+A `PI_DESKTOP_*` env override could be added later for unusual installs, but it
+is not needed for the install layouts above and is deliberately left out of this
+change.
+
+### Add a `PowerShell7` tool name
+
+Rejected: ADR 0054 §3 keeps `Bash` as the tool and protocol name and treats shell
+choice as request data. A second tool name would multiply permission and audit
+surfaces without adding authority.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -226,3 +226,4 @@ Each ADR includes:
 | 0206 | Extend provider retries and show bounded progress | Accepted |
 | 0207 | Allow three same-path mutation recovery failures | Accepted (amends 0087 / D186) |
 | 0208 | Plugin desktop control requires native user consent | Accepted |
+| 0209 | PowerShell 7 as a selectable Windows command shell | Proposed (issue #151; amends 0054 / D190) |

--- a/docs/project/plan-mode-implementation-plan.md
+++ b/docs/project/plan-mode-implementation-plan.md
@@ -36,7 +36,8 @@ host restart with no replay. A pending interruption leaves the session Plan;
 an already-approved queued or running interruption leaves it Agent.
 
 The Bash tool retains its protocol name while using a host shell catalog. The
-catalog IDs are `windows-powershell`, `cmd`, `git-bash`, and `bash`. The
+catalog IDs are `windows-powershell`, `windows-pwsh`, `cmd`, `git-bash`, and
+`bash`. The
 effective shell ID and dialect are pinned for each turn, stdout/stderr stream
 separately, the default timeout is exactly 60 seconds, explicit timeouts are
 bounded to 1-300 seconds, and cancellation shuts down the full process tree.
@@ -51,7 +52,7 @@ bounded to 1-300 seconds, and cancellation shuts down the full process tree.
 | Approval status | `pending`, `approved`, `rejected`, `expired`, `interrupted` | `plan_approvals.status` |
 | Execution state | `queued`, `running`, `completed`, `interrupted` | `plan_approvals.execution_state` |
 | Permission mode | `inherit`, `ask`, `accept-edits`, `auto` | Host settings/session policy |
-| Shell ID | `windows-powershell`, `cmd`, `git-bash`, `bash` | Host catalog/settings |
+| Shell ID | `windows-powershell`, `windows-pwsh`, `cmd`, `git-bash`, `bash` | Host catalog/settings |
 | Shell dialect | `powershell`, `cmd`, `posix` | Effective shell option |
 
 The renderer and sidecar hold projections. The renderer retains the latest Plan
@@ -210,7 +211,7 @@ Host-core returns a platform-aware catalog:
 
 | Platform | IDs in catalog |
 |---|---|
-| Windows | `windows-powershell`, `cmd`, `git-bash` |
+| Windows | `windows-powershell`, `windows-pwsh`, `cmd`, `git-bash` |
 | macOS/Linux | `bash` |
 
 Each option contains its stable ID, display label, dialect, availability, and

--- a/docs/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/spec/03-runtime/01-ipc-protocol.md
@@ -858,7 +858,12 @@ writes; it is not exposed or recreated.
 ### shell
 
 ```ts
-type CommandShellId = "windows-powershell" | "cmd" | "git-bash" | "bash";
+type CommandShellId =
+  | "windows-powershell"
+  | "windows-pwsh"
+  | "cmd"
+  | "git-bash"
+  | "bash";
 
 type CommandShellOption = {
   id: CommandShellId;

--- a/docs/spec/03-runtime/03-tools-and-permissions.md
+++ b/docs/spec/03-runtime/03-tools-and-permissions.md
@@ -330,8 +330,8 @@ Host execution baseline:
   `errorCode: TOOL_FAILED` while preserving its `exitCode`, stdout, and stderr
   in `content` so the agent can diagnose the command without blindly retrying.
 
-Shell catalog (D190) exposes the stable IDs `windows-powershell`, `cmd`,
-`git-bash`, and `bash` where supported by the platform. The host persists
+Shell catalog (D190) exposes the stable IDs `windows-powershell`, `windows-pwsh`,
+`cmd`, `git-bash`, and `bash` where supported by the platform. The host persists
 `defaultCommandShell`; if that persisted choice later becomes unavailable, the
 effective catalog selection intentionally falls back to the first available
 platform shell. A turn pins the effective shell ID and dialect. `Bash` remains
@@ -357,6 +357,12 @@ or executable path hash is accepted as shell identity.
 - No bash bundled in the installer: Git for Windows is the Windows prerequisite (the app requires git anyway)
 - Resolution failure returns stable `SHELL_NOT_FOUND` with install guidance
 - Windows PowerShell and cmd use their native non-interactive invocation.
+- PowerShell 7 resolves `pwsh.exe` from `%ProgramFiles%\PowerShell\7` (or
+  `ProgramW6432` when the host process is 32-bit), then PATH, which covers
+  machine-scope, Store, user-scope, and portable installs. It shares the
+  Windows PowerShell 5.1 invocation contract and is never selected implicitly,
+  so it cannot change an existing user's default shell. Resolution failure
+  returns `SHELL_NOT_FOUND` naming the locations that were searched.
 - Git Bash uses the discovered Git for Windows executable.
 - Unix Bash uses an approved system Bash entry.
 - User abort and timeout terminate the complete process tree before returning.

--- a/docs/spec/03-runtime/06-host-rpc-protocol.md
+++ b/docs/spec/03-runtime/06-host-rpc-protocol.md
@@ -826,7 +826,12 @@ field.
 ### 5.2 Shell catalog
 
 ```ts
-type CommandShellId = "windows-powershell" | "cmd" | "git-bash" | "bash";
+type CommandShellId =
+  | "windows-powershell"
+  | "windows-pwsh"
+  | "cmd"
+  | "git-bash"
+  | "bash";
 
 type CommandShellOption = {
   id: CommandShellId;

--- a/docs/spec/04-ux/06-settings-ia.md
+++ b/docs/spec/04-ux/06-settings-ia.md
@@ -115,8 +115,9 @@ Settings is a **full-window page** that replaces the app sidebar + main chrome (
   The threshold controls when a text-only paste becomes a temporary
   session-scratch file; it defaults to 600 characters and accepts integer values
   from 1 through 1,000,000.
-- The **Command shell** row in Defaults uses the host-discovered catalog of native PowerShell,
-  cmd, Git Bash, and Bash with IDs `windows-powershell`, `cmd`, `git-bash`, and
+- The **Command shell** row in Defaults uses the host-discovered catalog of native
+  PowerShell 5.1, PowerShell 7, cmd, Git Bash, and Bash with IDs
+  `windows-powershell`, `windows-pwsh`, `cmd`, `git-bash`, and
   `bash` where supported. The selected `defaultCommandShell` persists across
   restart; writes reject unavailable or wrong-platform IDs. If a persisted
   choice later becomes unavailable, the first available platform shell is used

--- a/docs/spec/05-security/01-security.md
+++ b/docs/spec/05-security/01-security.md
@@ -101,7 +101,7 @@ replace an artifact.
 - Bash requires confirmation by default (risk-tiered permission cards); in
   either Agent or Plan, explicit Auto may run it without confirmation
 - The Bash protocol name remains stable, but host-core selects a catalog shell
-  (`windows-powershell`, `cmd`, `git-bash`, or `bash`) from persisted
+  (`windows-powershell`, `windows-pwsh`, `cmd`, `git-bash`, or `bash`) from persisted
   `defaultCommandShell` where supported by the platform. Settings writes reject
   unavailable/wrong-platform IDs. If a persisted choice later becomes
   unavailable, catalog resolution intentionally falls back to the first

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -4779,7 +4779,7 @@ Each scenario is documented in this format:
   make a persisted choice unavailable, and a project-bound Agent session is
   idle. The Windows lane exercises the multi-choice ordering.
 - **Steps**: 1) Inspect the catalog for the platform-valid IDs
-  `windows-powershell`, `cmd`, `git-bash`, and `bash`. 2) Verify settings
+  `windows-powershell`, `windows-pwsh`, `cmd`, `git-bash`, and `bash`. 2) Verify settings
   rejects an unavailable or wrong-platform ID. 3) Select an available shell
   and persist `defaultCommandShell`. 4) Make that persisted choice unavailable,
   restart, and verify the catalog selects the first available platform shell

--- a/docs/spec/08-meta/decisions-log.md
+++ b/docs/spec/08-meta/decisions-log.md
@@ -4241,14 +4241,14 @@ D193, and D194.
   instead of inheriting the global workspace. See E2E-234 through
   E2E-238.
 
-## 2026-09-10 — PowerShell 7 as a selectable Windows command shell (D380)
+## 2026-09-10 — PowerShell 7 as a selectable Windows command shell (D381)
 
 - Issue #151: a Windows user who installs PowerShell 7 (`pwsh.exe`) had no way to
   run `Bash` under it. PowerShell 7 installs side by side with, and never
   replaces, the in-box 5.1 that ADR 0054's `windows-powershell` entry resolves,
   and the catalog exposed no other entry: `crates/host-core/src/tools/shell.rs`
   had no `pwsh.exe` resolution path, and `COMMAND_SHELL_IDS` listed four IDs.
-- Decision D380 (ADR 0209) adds the stable ID `windows-pwsh` ("PowerShell 7") to
+- Decision D381 (ADR 0209) adds the stable ID `windows-pwsh` ("PowerShell 7") to
   the Windows catalog, amending ADR 0054 §1. It resolves
   `%ProgramFiles%\PowerShell\7\pwsh.exe` (plus `%ProgramW6432%` when the host
   process is 32-bit), then `pwsh.exe` on PATH; a miss returns `SHELL_NOT_FOUND`

--- a/docs/spec/08-meta/decisions-log.md
+++ b/docs/spec/08-meta/decisions-log.md
@@ -4240,3 +4240,22 @@ D193, and D194.
   a `tools.execute` for an unknown session returns `SESSION_NOT_FOUND`
   instead of inheriting the global workspace. See E2E-234 through
   E2E-238.
+
+## 2026-09-10 — PowerShell 7 as a selectable Windows command shell (D380)
+
+- Issue #151: a Windows user who installs PowerShell 7 (`pwsh.exe`) had no way to
+  run `Bash` under it. PowerShell 7 installs side by side with, and never
+  replaces, the in-box 5.1 that ADR 0054's `windows-powershell` entry resolves,
+  and the catalog exposed no other entry: `crates/host-core/src/tools/shell.rs`
+  had no `pwsh.exe` resolution path, and `COMMAND_SHELL_IDS` listed four IDs.
+- Decision D380 (ADR 0209) adds the stable ID `windows-pwsh` ("PowerShell 7") to
+  the Windows catalog, amending ADR 0054 §1. It resolves
+  `%ProgramFiles%\PowerShell\7\pwsh.exe` (plus `%ProgramW6432%` when the host
+  process is 32-bit), then `pwsh.exe` on PATH; a miss returns `SHELL_NOT_FOUND`
+  naming both searched locations. It keeps the `powershell` dialect and the
+  pinned non-interactive script, and it is never selected implicitly, so the
+  platform default and existing users' shells are unchanged.
+- Protocol, storage, and tool surfaces are additive: `CommandShellId` gains one
+  member while the folded settings validation and the first-available fallback
+  need no new code path, and no RPC method, tool name, or schema migration is
+  added. See E2E-112.

--- a/docs/zh-CN/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/zh-CN/spec/03-runtime/01-ipc-protocol.md
@@ -742,7 +742,12 @@ sidecar 用于显示每秒输出令牌的流时间。 `ToolTokenUsage`
 ### shell
 
 ```ts
-type CommandShellId = "windows-powershell" | "cmd" | "git-bash" | "bash";
+type CommandShellId =
+  | "windows-powershell"
+  | "windows-pwsh"
+  | "cmd"
+  | "git-bash"
+  | "bash";
 
 type CommandShellOption = {
   id: CommandShellId;

--- a/docs/zh-CN/spec/03-runtime/03-tools-and-permissions.md
+++ b/docs/zh-CN/spec/03-runtime/03-tools-and-permissions.md
@@ -312,7 +312,7 @@ sidecar 的工具计时线包括 `mutationFailureKind` 和
   `errorCode: TOOL_FAILED`，同时保留其 `exitCode`、stdout 和 stderr
   在 `content` 中，以便代理可以诊断命令而无需盲目重试。
 
-Shell 目录 (D190) 公开稳定 ID `windows-powershell`、`cmd`、
+Shell 目录 (D190) 公开稳定 ID `windows-powershell`、`windows-pwsh`、`cmd`、
 平台支持的 `git-bash` 和 `bash`。楼主坚持
 `defaultCommandShell`；如果那个持续的选择后来变得不可用，
 有效的目录选择有意回退到第一个可用的目录
@@ -339,6 +339,11 @@ tool/protocol 名称，请求中单独携带固定的 shell ID。
 - 安装程序中没有捆绑 bash：Windows 的 Git 是 Windows 的先决条件（无论如何，该应用程序都需要 git）
 - 解决失败返回稳定的 `SHELL_NOT_FOUND` 并提供安装指导
 - Windows PowerShell 和 cmd 使用其本机非交互式调用。
+- PowerShell 7 先解析 `%ProgramFiles%\PowerShell\7`（宿主进程为 32 位时为
+  `ProgramW6432`）下的 `pwsh.exe`，再回退到 PATH，覆盖机器级安装、Store、
+  用户级与便携安装。它与 Windows PowerShell 5.1 共用同一调用契约，且从不被
+  隐式选中，因此不会改变既有用户的默认 shell。解析失败返回
+  `SHELL_NOT_FOUND`，并列出已搜索的位置。
 - Git Bash 使用发现的 Git 来执行 Windows 可执行文件。
 - Unix Bash 使用经过批准的系统 Bash 条目。
 - 用户中止和超时在返回之前终止整个进程树。

--- a/docs/zh-CN/spec/03-runtime/06-host-rpc-protocol.md
+++ b/docs/zh-CN/spec/03-runtime/06-host-rpc-protocol.md
@@ -762,7 +762,12 @@ Agent 中的会话。进程纪元是内部的，不是线路或数据库
 ### 5. 2 Shell 目录
 
 ```ts
-type CommandShellId = "windows-powershell" | "cmd" | "git-bash" | "bash";
+type CommandShellId =
+  | "windows-powershell"
+  | "windows-pwsh"
+  | "cmd"
+  | "git-bash"
+  | "bash";
 
 type CommandShellOption = {
   id: CommandShellId;

--- a/docs/zh-CN/spec/04-ux/06-settings-ia.md
+++ b/docs/zh-CN/spec/04-ux/06-settings-ia.md
@@ -71,8 +71,9 @@
 - **默认项**卡：主机支持的默认运行模式（Agent / Plan / Goal）、
   命令 Shell 选择、回车发送控制和大段文本粘贴阈值。该阈值决定纯文本粘贴何时
   转为会话临时文件，默认值为 600 个字符，接受 1 至 1,000,000 的整数。
-- **默认项**卡中的**命令 Shell**行：主机发现的本机 PowerShell 目录，
-  cmd、Git Bash 和 ID 为 `windows-powershell`、`cmd`、`git-bash` 的 Bash 和
+- **默认项**卡中的**命令 Shell**行：主机发现的本机 PowerShell 5.1、PowerShell 7、
+  cmd、Git Bash 和 ID 为 `windows-powershell`、`windows-pwsh`、`cmd`、`git-bash`
+  的 Bash 和
   `bash`（如果支持）。选定的 `defaultCommandShell` 持续存在
   重新启动；写入拒绝不可用或错误的平台 ID。如果一个坚持
 选择稍后变得不可用，使用第一个可用的平台 shell

--- a/docs/zh-CN/spec/05-security/01-security.md
+++ b/docs/zh-CN/spec/05-security/01-security.md
@@ -99,7 +99,7 @@ CDP 插件工具在 Plan 中仍被拒绝）。 Bash 在 Plan 中仍然可用：�
 - Bash默认需要确认（风险分级权限卡）；在
   Agent 或 Plan，显式 Auto 可以在不确认的情况下运行它
 - Bash 协议名称保持稳定，但 host-core 选择目录 shell
-（`windows-powershell`、`cmd`、`git-bash` 或 `bash`）来自持久化
+（`windows-powershell`、`windows-pwsh`、`cmd`、`git-bash` 或 `bash`）来自持久化
   `defaultCommandShell` 受平台支持。设置写入拒绝
   unavailable/wrong-platform ID。如果一个坚持的选择后来变成
   不可用，目录分辨率故意回退到第一个

--- a/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
@@ -3690,7 +3690,7 @@ IPC 请求无法关闭。
   使持久选择不可用，并且项目绑定的 Agent 会话是
   闲置。 Windows 通道练习多选排序。
 - **步骤**：1) 检查目录中的平台有效 ID
-  `windows-powershell`、`cmd`、`git-bash` 和 `bash`。 2) 验证设置
+  `windows-powershell`、`windows-pwsh`、`cmd`、`git-bash` 和 `bash`。 2) 验证设置
   拒绝不可用或错误的平台 ID。 3）选择可用的shell
   并坚持 `defaultCommandShell`。 4）使坚持的选择不可用，
   重新启动，并验证目录选择第一个可用的平台 shell

--- a/docs/zh-CN/spec/08-meta/decisions-log.md
+++ b/docs/zh-CN/spec/08-meta/decisions-log.md
@@ -3634,14 +3634,14 @@ D193 和 D194。
   对未知会话的 `tools.execute` 返回 `SESSION_NOT_FOUND`，而不是继承全局工作区。
   参见 E2E-234 至 E2E-238。
 
-## 2026-09-10 — 将 PowerShell 7 作为 Windows 可选命令 Shell (D380)
+## 2026-09-10 — 将 PowerShell 7 作为 Windows 可选命令 Shell (D381)
 
 - 问题 #151：Windows 用户安装 PowerShell 7（`pwsh.exe`）后无法让 `Bash` 在它下面
   运行。PowerShell 7 与 ADR 0054 中 `windows-powershell` 条目所解析的随系统内置
   5.1 并排安装，且从不替换它，而目录中没有其它可选条目：
   `crates/host-core/src/tools/shell.rs` 没有 `pwsh.exe` 解析路径，
   `COMMAND_SHELL_IDS` 只列出四个 ID。
-- 决策 D380（ADR 0209）在 Windows 目录中新增稳定 ID `windows-pwsh`
+- 决策 D381（ADR 0209）在 Windows 目录中新增稳定 ID `windows-pwsh`
   （"PowerShell 7"），并修订 ADR 0054 §1。解析顺序为
   `%ProgramFiles%\PowerShell\7\pwsh.exe`（宿主进程为 32 位时追加
   `%ProgramW6432%`），再到 PATH 上的 `pwsh.exe`；解析失败返回

--- a/docs/zh-CN/spec/08-meta/decisions-log.md
+++ b/docs/zh-CN/spec/08-meta/decisions-log.md
@@ -3633,3 +3633,20 @@ D193 和 D194。
   `<data_dir>/ignore`；路径解析器会跟随悬空符号链接，因此经由它的写入无法离开工作区；
   对未知会话的 `tools.execute` 返回 `SESSION_NOT_FOUND`，而不是继承全局工作区。
   参见 E2E-234 至 E2E-238。
+
+## 2026-09-10 — 将 PowerShell 7 作为 Windows 可选命令 Shell (D380)
+
+- 问题 #151：Windows 用户安装 PowerShell 7（`pwsh.exe`）后无法让 `Bash` 在它下面
+  运行。PowerShell 7 与 ADR 0054 中 `windows-powershell` 条目所解析的随系统内置
+  5.1 并排安装，且从不替换它，而目录中没有其它可选条目：
+  `crates/host-core/src/tools/shell.rs` 没有 `pwsh.exe` 解析路径，
+  `COMMAND_SHELL_IDS` 只列出四个 ID。
+- 决策 D380（ADR 0209）在 Windows 目录中新增稳定 ID `windows-pwsh`
+  （"PowerShell 7"），并修订 ADR 0054 §1。解析顺序为
+  `%ProgramFiles%\PowerShell\7\pwsh.exe`（宿主进程为 32 位时追加
+  `%ProgramW6432%`），再到 PATH 上的 `pwsh.exe`；解析失败返回
+  `SHELL_NOT_FOUND` 并列出两处已搜索位置。它沿用 `powershell` 方言与既有的
+  非交互式脚本，且从不会被隐式选中，因此平台默认值与既有用户的 shell 保持不变。
+- 协议、存储与工具面均为增量改动：`CommandShellId` 新增一个成员，而折叠的
+  设置校验与首个可用回退无需新代码路径，也没有新增 RPC 方法、工具名或schema 迁移。
+  参见 E2E-112。

--- a/packages/shared/src/command-shells.ts
+++ b/packages/shared/src/command-shells.ts
@@ -1,5 +1,6 @@
 export const COMMAND_SHELL_IDS = [
   "windows-powershell",
+  "windows-pwsh",
   "cmd",
   "git-bash",
   "bash",
@@ -65,7 +66,10 @@ export function isCommandShellId(value: unknown): value is CommandShellId {
 
 export function commandShellDialect(id: CommandShellId): CommandShellDialect {
   switch (id) {
+    // Windows PowerShell 5.1 and PowerShell 7 share the invocation contract;
+    // only the resolved executable differs.
     case "windows-powershell":
+    case "windows-pwsh":
       return "powershell";
     case "cmd":
       return "cmd";

--- a/scripts/e2e-plan.mjs
+++ b/scripts/e2e-plan.mjs
@@ -437,7 +437,7 @@ async function verifyArtifact(ctx, proposal, markdown, title, question) {
 }
 
 function shellDialectForId(id) {
-  if (id === "windows-powershell") return "powershell";
+  if (id === "windows-powershell" || id === "windows-pwsh") return "powershell";
   if (id === "cmd") return "cmd";
   if (id === "git-bash" || id === "bash") return "posix";
   return undefined;
@@ -961,7 +961,7 @@ async function scenario112(binary, tempRoot) {
     assert(choices.length > 0, `empty shell catalog: ${shortJson(catalog)}`);
     const expectedIds =
       process.platform === "win32"
-        ? ["windows-powershell", "cmd", "git-bash"]
+        ? ["windows-powershell", "windows-pwsh", "cmd", "git-bash"]
         : ["bash"];
     for (const id of expectedIds) {
       assert(choices.some((choice) => choice.id === id), `missing platform shell ${id}`);


### PR DESCRIPTION
## Summary

A Windows user who installs PowerShell 7 (`pwsh.exe`) cannot run the `Bash` tool under it. PowerShell 7 installs **side by side with, and never replaces,** the in-box Windows PowerShell 5.1 that the existing `windows-powershell` entry resolves, and the catalog exposed no other entry, so the shell stayed 5.1.

Reported as #151.

This adds the stable ID `windows-pwsh` ("PowerShell 7") to the Windows shell catalog.

## Verification of the issue before implementing

Per AGENTS.md, the claim was checked against the current codebase rather than taken at face value:

- `crates/host-core/src/tools/shell.rs` had no `pwsh.exe` resolution path, and `choices_for_platform` returned exactly three Windows entries (`windows-powershell`, `cmd`, `git-bash`).
- `COMMAND_SHELL_IDS` in `packages/shared/src/command-shells.ts` listed four IDs.
- A repository-wide search for `pwsh` returned **no matches** in code or docs.

So the capability was genuinely missing, not misconfigured.

## What changed

**Resolution order** for `windows-pwsh`:

1. `%ProgramFiles%\PowerShell\7\pwsh.exe` — a machine-scope MSI or `winget --scope machine` install. `%ProgramW6432%` is probed too, so a 32-bit host process on 64-bit Windows (where `ProgramFiles` points at the x86 tree) still finds a real 64-bit install.
2. `pwsh.exe` on PATH — Store, user-scope, and portable installs.

A miss returns `SHELL_NOT_FOUND` with guidance that names both searched locations, instead of a bare "not found" (`PWSH_MISSING_GUIDANCE`).

**One invocation contract.** Both PowerShell generations accept the same non-interactive flags, so the dialect stays `powershell` and the existing pinned script (UTF-8 output setup, `$LASTEXITCODE` propagation) is reused unchanged. The catalog ID stays distinct so a pinned turn and `COMMAND_SHELL_CHANGED` still compare exactly.

**The platform default does not change.** The in-box 5.1 entry keeps `is_default` and stays the unset default; opting into 7 is an explicit Settings action.

## One behavior change to be aware of

The first-available fallback follows catalog order (ADR 0054 §1), and `windows-pwsh` sits directly after the in-box entry. A persisted `windows-powershell` that later becomes unavailable therefore resolves to `windows-pwsh` before `cmd`.

This follows the existing fallback rule rather than adding a new one, and it cannot change the command language — both entries share the `powershell` dialect. On Windows the in-box 5.1 entry is effectively always present, so the case is not reachable for a normal install. The existing catalog test is updated to pin **both** steps of the order rather than only its first result.

## Documentation

`docs/adr/0209` records the decision, the resolution order, and the rejected alternatives; ADR 0054 §1 gains the catalog row. The ID is also synchronized across:

- `spec/03-runtime/01-ipc-protocol.md`, `06-host-rpc-protocol.md`, `03-tools-and-permissions.md`
- `spec/04-ux/06-settings-ia.md`, `spec/05-security/01-security.md`
- `spec/06-delivery/04-e2e-test-plan.md` (E2E-112)
- `docs/project/plan-mode-implementation-plan.md`
- `spec/08-meta/decisions-log.md` (D381)
- all corresponding `docs/zh-CN/` mirrors
- `scripts/e2e-plan.mjs` (the E2E shell ID → dialect map and the expected Windows list)

## Alternatives considered

- **Make `windows-powershell` prefer `pwsh.exe` when present.** Rejected: it silently changes the shell an existing user already runs, and it makes the pinned turn identity ambiguous between two executables sharing a dialect. It also cannot express "use 5.1" once 7 is installed.
- **Add a `PI_DESKTOP_PWSH` env override** (mirroring `PI_DESKTOP_BASH`). Deliberately left out to keep the change small; the two probed locations cover the standard install layouts. Happy to add it if you prefer.
- **A separate `PowerShell7` tool name.** Rejected by ADR 0054 §3 — `Bash` stays the tool/protocol name.

If you would rather this be a new ADR number than 0209, or want `windows-pwsh` renamed, say so and I will renumber/rename.

## Validation

- `cargo +1.95.0 test -p host-core shell::` — **9 passed, 0 failed** (6 pre-existing plus 3 new tests: catalog shape, the shared invocation contract, and both steps of the fallback order).
- `cargo +1.95.0 test -p host-core` — the affected module passes; the shell-adjacent RPC tests (`bash_rejects_a_changed_shell_before_running_the_command`, `bash_output_is_streamed_with_shell_identity_and_unicode`) pass.

  Note: on this machine the full suite reports 15 pre-existing failures in `mcp_servers`, `rpc`, `sessions`, `tools`, `user_skills`, and `workspace` — all Windows canonical-path mismatches (`C:/` vs `C:\`, the `\\?\` prefix, temp-dir canonicalization). They reproduce unchanged on **unmodified `main`** (`workspace::tests` fails the identical 5 tests with the diff applied or reverted), so they are environmental and unrelated to this change.

- `command-shells.ts` exercised directly on Node 22 type-stripping: the new ID, the `powershell` dialect mapping, rejection of a wrong-dialect option, and the unchanged Windows default.

I could not run `pnpm typecheck` locally. `pnpm install` cannot finish in this sandbox. It resolves and reuses every package from the local store (`resolved 796, reused 796, downloaded 0`), then aborts in the linking phase: it must delete a staging directory holding more than 50 entries, and the sandbox refuses bulk deletes of that size (`[safe-delete][SAFE_DELETE_BULK_CONFIRM_REQUIRED] {"count":791,"threshold":50}`). This is an environment limitation, not a network one.

This repository also runs **no test workflow on pull requests** — `gh pr checks` reports only `Vercel / Authorization required to deploy` — so there is no CI run behind the TypeScript side either. The checks above are the full signal available here; `pnpm typecheck` needs a machine without that delete guard.


---

Numbering note: the decision is **D381**. Upstream `8ce8ed36` claimed D380 after this
branch was opened, so the entry moved up to keep the two distinct; ADR 0054, ADR 0209
and both decisions logs follow. The sibling PRs are #192 at D382 and #193 at D383, so
the three stay unique and in order.

