### PR TITLE
fix(desktop): fit chat markdown tables to container width

### DIFF
--- a/apps/desktop/src/styles/prose.css
+++ b/apps/desktop/src/styles/prose.css
@@ -356,7 +356,7 @@
 .prose-chat .table-wrap {
   margin: 0.9em 0;
   max-width: 100%;
-  width: fit-content;
+  width: 100%;
   overflow-x: auto;
   border-radius: var(--radius-md-plus);
 }
@@ -367,9 +367,8 @@
 
 .prose-chat .table-wrap table {
   margin: 0;
-  width: max-content;
-  min-width: 100%;
-  max-width: none;
+  width: 100%;
+  table-layout: auto;
   border-collapse: collapse;
   font-size: var(--text-md);
   line-height: var(--leading-normal);
@@ -380,6 +379,7 @@
   padding: 9px 14px;
   text-align: left;
   vertical-align: top;
+  overflow-wrap: anywhere;
 }
 
 .prose-chat th {
@@ -388,7 +388,6 @@
   background: var(--ds-tile-deep);
   font-size: var(--text-sm-plus);
   letter-spacing: var(--tracking-wide);
-  white-space: nowrap;
 }
 
 .prose-chat tbody tr:nth-child(even) td {


### PR DESCRIPTION
## Problem

Chat transcript tables are laid out with `width: max-content`, `max-width: none`, and `white-space: nowrap` on headers. Any table with many columns or long cell content overflows the chat column and forces horizontal scrolling (cells are clipped on the right until the user scrolls).

## Cause

In `apps/desktop/src/styles/prose.css`:

- `.prose-chat .table-wrap` used `width: fit-content`
- `.prose-chat .table-wrap table` used `width: max-content; min-width: 100%; max-width: none`
- `.prose-chat th` used `white-space: nowrap`

Together these let the table grow to its intrinsic content width regardless of the available space.

## Fix

- `.table-wrap`: `width: 100%` (keeps `overflow-x: auto` as a fallback for truly unbreakable content)
- `table`: `width: 100%` + `table-layout: auto`, so columns size by content but are capped at the container width
- `th, td`: `overflow-wrap: anywhere` so long tokens (URLs, model IDs, code) wrap instead of overflowing
- `th`: drop `white-space: nowrap` so headers can wrap too

## Result

Tables now always fit the transcript width: columns compress and cell text wraps, matching the behavior of other chat clients (e.g. Codex desktop). Narrow tables are unaffected visually apart from stretching to full width. No markup or component changes — CSS only.

## Testing

- Inspected the rendered chat tables with many-column and long-cell markdown: table stays within the transcript column, cells wrap, no horizontal scrollbar
- Alternating row colors, header tile, hover states, and border radius unchanged