### PR TITLE
fix(mcp): recover discovered tools after transport loss

### DIFF
--- a/apps/desktop/electron/main/user-mcp.ts
+++ b/apps/desktop/electron/main/user-mcp.ts
@@ -14,7 +14,8 @@ import type { McpServerClient, McpTool } from "./plugin-mcp";
  * server is connected the first time a session that can see it is assembled,
  * and its tool list is cached afterwards, so opening a second session on the
  * same project costs nothing. Editing or disabling a server drops its
- * connection, because a stale tool list is worse than a missing one.
+ * connection. Previously discovered names survive transport loss as routing
+ * hints, never as permission to call a tool absent from the new handshake.
  */
 export type UserMcpToolDescriptor = {
   /** `mcp_<serverId>_<tool>`, the name the model calls. */
@@ -54,6 +55,7 @@ type Entry = {
   record: McpServerRecord;
   client: UserMcpClient;
   status: McpServerStatus;
+  connecting?: Promise<McpTool[]>;
 };
 
 /**
@@ -67,6 +69,9 @@ const MAX_ACTIVE_SERVERS = 16;
 
 export class UserMcpRuntime {
   private entries = new Map<string, Entry>();
+  // Routing identity must survive a transport clearing its own tools on close.
+  // These names are hints only: dispatch revalidates the fresh handshake list.
+  private discoveredTools = new Map<string, McpTool[]>();
   private records: McpServerRecord[] = [];
   private options: UserMcpRuntimeOptions;
 
@@ -84,6 +89,9 @@ export class UserMcpRuntime {
   setRecords(records: McpServerRecord[]): void {
     this.records = records.map((record) => ({ ...record }));
     const byId = new Map(this.records.map((record) => [record.id, record]));
+    for (const id of this.discoveredTools.keys()) {
+      if (!byId.has(id)) this.discoveredTools.delete(id);
+    }
     for (const [id, entry] of [...this.entries]) {
       const next = byId.get(id);
       if (!next || configurationChanged(entry.record, next)) {
@@ -147,7 +155,7 @@ export class UserMcpRuntime {
     return out;
   }
 
-  /** Whether a tool name belongs to this runtime at all. */
+  /** Whether a saved server advertised this name (not a readiness check). */
   hasTool(fullName: string): boolean {
     return this.findTool(fullName) !== undefined;
   }
@@ -176,17 +184,31 @@ export class UserMcpRuntime {
         { errorCode: "TOOL_NOT_FOUND" },
       );
     }
-    const entry = this.entries.get(found.serverId);
-    if (!entry) {
-      await this.connect(record);
+    await this.connect(record);
+    // Configuration or scope can change while the handshake is in flight.
+    const current = this.records.find((entry) => entry.id === found.serverId);
+    if (!current || !isActiveInProject(current, projectPath)) {
+      throw Object.assign(
+        new Error(`mcp server ${found.serverId} is not active for this session`),
+        { errorCode: "TOOL_NOT_FOUND" },
+      );
     }
-    const client = this.entries.get(found.serverId)?.client;
-    if (!client) {
+    const entry = this.entries.get(found.serverId);
+    if (
+      !entry || configurationChanged(record, current) ||
+      entry.status.state !== "ready" || !entry.client.isConnected()
+    ) {
       throw Object.assign(new Error(`mcp server ${found.serverId} is unavailable`), {
         errorCode: "UNAVAILABLE",
       });
     }
-    return client.callTool(found.toolName, args);
+    if (!entry.client.getTools().some((tool) => tool.name === found.toolName)) {
+      throw Object.assign(new Error(`unknown mcp tool: ${fullName}`), {
+        errorCode: "TOOL_NOT_FOUND",
+      });
+    }
+    // Do not retry tools/call: a failed response may have followed a mutation.
+    return entry.client.callTool(found.toolName, args);
   }
 
   /**
@@ -217,11 +239,12 @@ export class UserMcpRuntime {
   disposeAll(): void {
     for (const entry of this.entries.values()) entry.client.close();
     this.entries.clear();
+    this.discoveredTools.clear();
   }
 
   private findTool(fullName: string): UserMcpToolDescriptor | undefined {
-    for (const [serverId, entry] of this.entries) {
-      for (const tool of entry.client.getTools()) {
+    for (const [serverId, tools] of this.discoveredTools) {
+      for (const tool of tools) {
         if (userMcpToolName(serverId, tool.name) === fullName) {
           return {
             fullName,
@@ -238,12 +261,20 @@ export class UserMcpRuntime {
 
   private async connect(record: McpServerRecord): Promise<McpTool[]> {
     const existing = this.entries.get(record.id);
+    if (existing?.connecting) return existing.connecting;
     if (existing?.client.isConnected()) return existing.client.getTools();
     // A server that already failed its handshake this run stays failed until the
     // user edits it or asks for a test, so every session assembly does not pay
     // the connect timeout again.
     if (existing?.status.state === "failed") return [];
     const entry = existing ?? this.createEntry(record);
+    entry.connecting = this.handshake(record, entry).finally(() => {
+      entry.connecting = undefined;
+    });
+    return entry.connecting;
+  }
+
+  private async handshake(record: McpServerRecord, entry: Entry): Promise<McpTool[]> {
     entry.status = {
       ...entry.status,
       state: "connecting",
@@ -251,6 +282,12 @@ export class UserMcpRuntime {
     };
     try {
       const tools = await entry.client.connect();
+      // An edited/deleted record must not resurrect a discarded connection.
+      if (this.entries.get(record.id) !== entry) {
+        entry.client.close();
+        return [];
+      }
+      this.discoveredTools.set(record.id, [...tools]);
       entry.status = {
         serverId: record.id,
         state: "ready",

--- a/apps/desktop/test/user-mcp.test.mjs
+++ b/apps/desktop/test/user-mcp.test.mjs
@@ -168,12 +168,30 @@ test("editing what a server runs drops the live connection", async (t) => {
   assert.match(JSON.stringify(await rt.callTool("mcp_stub_lookup", {}, "/repo")), /first:lookup/);
 
   rt.setRecords([stubRecord(dir, { env: { STUB_TAG: "second" } })]);
-  // The old client is gone, so the tool cache is empty until the next assembly.
-  assert.equal(rt.hasTool("mcp_stub_lookup"), false);
+  // Routing survives the edit, but dispatch must handshake the new config.
+  assert.equal(rt.hasTool("mcp_stub_lookup"), true);
   assert.equal(rt.statusFor("stub").state, "idle");
 
-  await rt.toolsForProject("/repo");
   assert.match(JSON.stringify(await rt.callTool("mcp_stub_lookup", {}, "/repo")), /second:lookup/);
+});
+
+test("a terminated stdio process recovers on the next tool call", async (t) => {
+  const dir = stubDir();
+  const pidFile = join(dir, "pid");
+  let client;
+  const rt = runtime(t, {
+    createClient: (config) => { client = new McpServerClient(config); return client; },
+  });
+  rt.setRecords([stubRecord(dir, { env: { STUB_PID_FILE: pidFile } })]);
+  await rt.toolsForProject("/repo");
+  process.kill(Number(readFileSync(pidFile, "utf8")), "SIGTERM");
+  for (let attempt = 0; client.isConnected() && attempt < 100; attempt += 1) {
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  assert.equal(client.isConnected(), false);
+  assert.deepEqual(client.getTools(), []);
+  assert.match(JSON.stringify(await rt.callTool("mcp_stub_lookup", {}, "/repo")), /lookup/);
+  assert.equal(rt.statusFor("stub").state, "ready");
 });
 
 test("changing only scope or label keeps the connection", async (t) => {
@@ -187,6 +205,134 @@ test("changing only scope or label keeps the connection", async (t) => {
   ]);
   assert.equal(rt.statusFor("stub").state, "ready");
   assert.equal(rt.hasTool("mcp_stub_lookup"), true);
+});
+
+/** A transport disconnect clears the client's tools, just like onClose. */
+function reconnectingRuntime(t) {
+  let connected = false;
+  let tools = [];
+  const state = { handshakes: 0, calls: [], advertised: [{ name: "lookup" }], fail: false, gate: null };
+  const client = {
+    isConnected: () => connected,
+    getTools: () => tools,
+    close: () => { connected = false; tools = []; },
+    connect: async () => {
+      state.handshakes += 1;
+      await state.gate;
+      if (state.fail) throw new Error("offline");
+      connected = true;
+      tools = state.advertised;
+      return tools;
+    },
+    callTool: async (name) => { state.calls.push(name); return name; },
+  };
+  const rt = new UserMcpRuntime({ createClient: () => client });
+  t.after(() => rt.disposeAll());
+  rt.setRecords([stubRecord("/unused")]);
+  return { rt, client, state };
+}
+
+test("an advertised tool reconnects after transport loss without another search", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await rt.toolsForProject("/repo");
+  client.close();
+  assert.equal(await rt.callTool("mcp_stub_lookup", {}, "/repo"), "lookup");
+  assert.equal(state.handshakes, 2);
+  assert.deepEqual(state.calls, ["lookup"]);
+});
+
+test("reconnection revalidates the advertised tool list before dispatch", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await rt.toolsForProject("/repo");
+  client.close();
+  state.advertised = [{ name: "replacement" }];
+  await assert.rejects(rt.callTool("mcp_stub_lookup", {}, "/repo"), { errorCode: "TOOL_NOT_FOUND" });
+  assert.equal(state.handshakes, 2);
+  assert.deepEqual(state.calls, []);
+});
+
+test("a failed reconnect reports unavailability without repeated handshakes", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await rt.toolsForProject("/repo");
+  client.close();
+  state.fail = true;
+  for (let i = 0; i < 2; i += 1) {
+    await assert.rejects(rt.callTool("mcp_stub_lookup", {}, "/repo"), { errorCode: "UNAVAILABLE" });
+  }
+  assert.equal(state.handshakes, 2);
+  assert.deepEqual(state.calls, []);
+});
+
+test("scope and enablement are checked before reconnecting a remembered tool", async (t) => {
+  for (const change of [{ enabled: false }, { scope: { mode: "projects", projects: ["/other"] } }]) {
+    const { rt, client, state } = reconnectingRuntime(t);
+    await rt.toolsForProject("/repo");
+    client.close();
+    rt.setRecords([stubRecord("/unused", change)]);
+    await assert.rejects(rt.callTool("mcp_stub_lookup", {}, "/repo"), (error) => {
+      assert.equal(error.errorCode, "TOOL_NOT_FOUND");
+      assert.match(error.message, /not active for this session/);
+      return true;
+    });
+    assert.equal(state.handshakes, 1);
+    assert.deepEqual(state.calls, []);
+  }
+});
+
+test("concurrent calls share one recovery handshake", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await rt.toolsForProject("/repo");
+  client.close();
+  let release;
+  state.gate = new Promise((resolve) => { release = resolve; });
+  const first = rt.callTool("mcp_stub_lookup", {}, "/repo");
+  const second = rt.callTool("mcp_stub_lookup", {}, "/repo");
+  assert.equal(state.handshakes, 2);
+  release();
+  assert.deepEqual(await Promise.all([first, second]), ["lookup", "lookup"]);
+});
+
+test("scope changes during recovery prevent dispatch", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await rt.toolsForProject("/repo");
+  client.close();
+  let release;
+  state.gate = new Promise((resolve) => { release = resolve; });
+  const pending = rt.callTool("mcp_stub_lookup", {}, "/repo");
+  rt.setRecords([stubRecord("/unused", { scope: { mode: "projects", projects: ["/other"] } })]);
+  release();
+  await assert.rejects(pending, { errorCode: "TOOL_NOT_FOUND" });
+  assert.deepEqual(state.calls, []);
+});
+
+test("removing a server during recovery cannot restore its tools", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await rt.toolsForProject("/repo");
+  client.close();
+  let release;
+  state.gate = new Promise((resolve) => { release = resolve; });
+  const pending = rt.callTool("mcp_stub_lookup", {}, "/repo");
+  rt.setRecords([]);
+  release();
+  await assert.rejects(pending, { errorCode: "TOOL_NOT_FOUND" });
+  assert.equal(rt.hasTool("mcp_stub_lookup"), false);
+  assert.equal(client.isConnected(), false);
+  assert.deepEqual(state.calls, []);
+});
+
+test("unknown names never cause a handshake and failed calls are not replayed", async (t) => {
+  const { rt, client, state } = reconnectingRuntime(t);
+  await assert.rejects(rt.callTool("mcp_stub_lookup", {}, "/repo"), { errorCode: "TOOL_NOT_FOUND" });
+  assert.equal(state.handshakes, 0);
+  await rt.toolsForProject("/repo");
+  client.callTool = async (name) => {
+    state.calls.push(name);
+    client.close();
+    throw Object.assign(new Error("response lost"), { errorCode: "UNAVAILABLE" });
+  };
+  await assert.rejects(rt.callTool("mcp_stub_lookup", {}, "/repo"), { errorCode: "UNAVAILABLE" });
+  assert.deepEqual(state.calls, ["lookup"]);
+  assert.equal(state.handshakes, 1);
 });
 
 test("a broken server fails as status and is not retried every session", async (t) => {

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -5249,7 +5249,19 @@ Each scenario is documented in this format:
   8. Rename the server and re-scope it; ask once more.
   9. Point the server's command at a binary that does not exist, save, and open
      a new session.
+  10. Restore the valid command and Test connection. Activate a tool through
+      `ToolSearch`, then terminate the stub server process between calls. Call
+      the same tool in the existing session without searching again.
+  11. Repeat with the restarted stub omitting that tool, and with the server
+      disabled or scoped away before recovery. Also try concurrent calls after
+      a disconnect and a server that fails its recovery handshake.
 - **Expected**:
+  - The activated tool works after a transport restart without a second search;
+    concurrent calls share one handshake. The fresh server list must still
+    advertise the tool. Removed tools and inactive servers are refused without
+    executing a call; inactive servers are not reconnected. Recovery failure
+    returns `UNAVAILABLE` and does not trigger repeated handshake attempts until
+    an edit or Test connection. A failed tool execution is never replayed.
   - Two servers import; the third is listed as skipped with "a stdio server
      requires command". The LAN HTTP entry lands as `http` with its url intact,
      and the editor shows the unencrypted-connection warning.
@@ -5260,7 +5272,7 @@ Each scenario is documented in this format:
      reads "1 project" and names it.
   - The stale call from step 6 fails with `TOOL_NOT_FOUND` and "not active for
      this session" — scope holds at dispatch, not only in the catalog.
-  - The `env` edit drops the connection: the next assembly re-handshakes, and
+  - The `env` edit drops the connection: the next assembly or call re-handshakes, and
      the tool's behaviour reflects the new value. The rename in step 8 does not
      reconnect anything.
   - The broken command records `failed` with a message, contributes no tools,

--- a/docs/spec/07-plugins/01-plugin-system.md
+++ b/docs/spec/07-plugins/01-plugin-system.md
@@ -502,6 +502,17 @@ Rules the control encodes:
   environment/header rows, validation, duplicate checks, and Test connection.
 - Enablement is app-local and project records shadow global records before the
   active runtime filters disabled rows.
+- A previously advertised user MCP tool remains routable after transport loss
+  or a saved connection edit. The next call re-handshakes the current saved
+  server and validates the tool against its fresh list before dispatch; no
+  additional `ToolSearch` is required. Unknown names cannot trigger discovery.
+- Enablement and project scope are checked before and after recovery. Removing
+  a server or disposing the runtime discards its remembered names; an obsolete
+  in-flight handshake cannot restore them. Concurrent calls share a handshake.
+- A failed recovery reports `UNAVAILABLE` and retains the existing failed-server
+  policy (edit or Test connection to retry), rather than repeatedly connecting
+  on each call. Removed tools return `TOOL_NOT_FOUND`. Recovery never replays a
+  failed `tools/call`, which may already have performed a mutation.
 
 ### 12.3 Skills management in Settings > Agent
 


### PR DESCRIPTION
## Summary

Addresses the reproducible connection/cache-loss path in #102: a previously discovered user MCP tool can become `TOOL_NOT_FOUND` after its transport closes, before dispatch has a chance to reconnect.

## Reproduction and cause

`McpServerClient` clears its tool list on transport close. `UserMcpRuntime.findTool()` only searched that live list, so the saved server could still be enabled and in scope while the remembered tool name could no longer be resolved. The reconnect branch after lookup could not recover this case.

The regression test starts a real stdio stub, discovers its tools, terminates its process, waits for the client tool list to clear, then calls the original name without another discovery pass.

## Changes

- Retain previously advertised names separately from the connection as routing hints.
- Reconnect on demand and validate the requested tool against the current client's fresh list.
- Check enablement and project scope before and after the handshake; discard obsolete handshake results after a record is removed or replaced.
- Share an in-flight handshake between concurrent calls.
- Preserve the failed-handshake policy: edit or Test connection before retrying. Never replay a failed `tools/call`, which may already have performed a mutation.

Unknown names do not initiate discovery. Remembered names do not bypass scope checks or authorize tools removed by the server.

## Validation

- MCP runtime/client suites: **37 passed**, including real stdio process recovery, configuration edits, removed tools, unavailable servers, concurrent recovery, scope changes and removal during recovery, and no call replay.
- The first four new regression tests failed against the original implementation before the fix.
- Targeted strict TypeScript check of `user-mcp.ts` and its imports passed.
- `node scripts/check-style-tokens.mjs` and `git diff --check` passed.
- Updated the plugin-system spec and E2E-100. E2E execution was not requested and was not run; full application build/typecheck and repository-wide tests are left to CI.

This is an internal lifecycle fix, with no new IPC, schema, settings, or permission grants. It does not add tool-error logging or claim to explain every healthy-connection/compaction symptom reported in #102.
