### PR TITLE
fix(release): align the agent-host package version with 0.14.6

### DIFF
--- a/packages/agent-host/package.json
+++ b/packages/agent-host/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pi-desktop/agent-host",
-  "version": "0.14.6-rc.4",
+  "version": "0.14.6",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",


### PR DESCRIPTION
Fixes #200.

## Summary

`packages/agent-host/package.json` states `0.14.6-rc.4` while every other version surface states `0.14.6`. This restores the invariant that release-runbook 4.1 requires and makes the release preflight pass on `main`.

## Cause

`packages/agent-host` was added by `c9f7cd86` already carrying the stale `0.14.6-rc.4` version, and it was not advanced by the later `chore(release)` bumps for `v0.14.6-rc.5`, `v0.14.6-rc.6`, or `v0.14.6`.

## Reproduction

On `main` at `6e6d710e`:

```
$ node scripts/check-release-docs.mjs
Release documentation is not aligned with 0.14.6:
  - packages\agent-host\package.json: version is 0.14.6-rc.4, expected 0.14.6
$ echo $?
1
```

With this change:

```
$ node scripts/check-release-docs.mjs
Release documentation is aligned with 0.14.6 (0.14.x line).
$ echo $?
0
```

## Changes

- `packages/agent-host/package.json`: `0.14.6-rc.4` → `0.14.6`.

## Validation

- `node scripts/check-release-docs.mjs` — exit 1 before, exit 0 after. This is the script `scripts/release.mjs` runs before tagging and the one `pnpm check:release-docs` exposes.
- `pnpm install --frozen-lockfile` — passes with the change. The package is private and consumed as `workspace:*`, so `pnpm-lock.yaml` records `link:../../packages/agent-host` with no version and needs no update.
- `pnpm --filter @pi-desktop/agent-host build` — passes.
- `pnpm --filter @pi-desktop/agent-host test` — 34 tests pass.
- `node scripts/check-style-tokens.mjs` — passes.
- `git diff --check` — clean.

No spec, ADR, or E2E-documentation update is included: this is a version-surface alignment in a private workspace package, with no user-visible or protocol-visible behavior change (R1/R3 do not apply).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
