### PR TITLE
fix(docs): match locale notice routes with POSIX separators

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -7,7 +7,8 @@
     "dev": "vitepress dev .",
     "build": "vitepress build .",
     "preview": "vitepress preview .",
-    "check:locales": "node scripts/check-locales.mjs"
+    "check:locales": "node scripts/check-locales.mjs",
+    "test": "node --test"
   },
   "devDependencies": {
     "vitepress": "^1.6.4"

--- a/docs/scripts/check-locales.mjs
+++ b/docs/scripts/check-locales.mjs
@@ -13,9 +13,14 @@ function markdownFiles(directory) {
     .sort()
 }
 
-const englishFiles = markdownFiles(englishRoot)
-const missing = []
-const invalid = []
+/**
+ * Route the Chinese notice must link, built from a path relative to `docs/spec`.
+ * Routed links are POSIX, but `path.relative` separates with backslashes on
+ * Windows, so normalize the separators before assembling the route.
+ */
+export function noticeRoute(relativePath) {
+  return `/spec/${relativePath.split(path.sep).join('/').replace(/\.md$/, '')}`
+}
 
 function tableShape(source) {
   return source.split('\n')
@@ -24,34 +29,50 @@ function tableShape(source) {
     .map((line) => [...line].filter((character) => character === '|').length)
 }
 
-for (const relativePath of englishFiles) {
-  const translatedPath = path.join(chineseRoot, relativePath)
-  if (!fs.existsSync(translatedPath)) {
-    missing.push(relativePath)
-    continue
+export function verifyLocalePairs() {
+  const englishFiles = markdownFiles(englishRoot)
+  const missing = []
+  const invalid = []
+
+  for (const relativePath of englishFiles) {
+    const translatedPath = path.join(chineseRoot, relativePath)
+    if (!fs.existsSync(translatedPath)) {
+      missing.push(relativePath)
+      continue
+    }
+
+    const source = fs.readFileSync(translatedPath, 'utf8')
+    const englishSource = fs.readFileSync(path.join(englishRoot, relativePath), 'utf8')
+    const englishRoute = noticeRoute(relativePath)
+    const tableStructureMatches = JSON.stringify(tableShape(source)) === JSON.stringify(tableShape(englishSource))
+    const fenceStructureMatches = (source.match(/^```/gm) ?? []).length === (englishSource.match(/^```/gm) ?? []).length
+    if (
+      !/^#\s+\S+/m.test(source)
+      || !/[\u3400-\u9fff]/.test(source)
+      || !source.includes(`[英文源规格](${englishRoute})`)
+      || source.includes('PIHOLDTOKEN')
+      || !tableStructureMatches
+      || !fenceStructureMatches
+    ) {
+      invalid.push(relativePath)
+    }
   }
 
-  const source = fs.readFileSync(translatedPath, 'utf8')
-  const englishSource = fs.readFileSync(path.join(englishRoot, relativePath), 'utf8')
-  const englishRoute = `/spec/${relativePath.replace(/\.md$/, '')}`
-  const tableStructureMatches = JSON.stringify(tableShape(source)) === JSON.stringify(tableShape(englishSource))
-  const fenceStructureMatches = (source.match(/^```/gm) ?? []).length === (englishSource.match(/^```/gm) ?? []).length
-  if (
-    !/^#\s+\S+/m.test(source)
-    || !/[\u3400-\u9fff]/.test(source)
-    || !source.includes(`[英文源规格](${englishRoute})`)
-    || source.includes('PIHOLDTOKEN')
-    || !tableStructureMatches
-    || !fenceStructureMatches
-  ) {
-    invalid.push(relativePath)
+  return { englishFiles, missing, invalid }
+}
+
+function main() {
+  const { englishFiles, missing, invalid } = verifyLocalePairs()
+
+  if (missing.length || invalid.length) {
+    if (missing.length) console.error(`Missing Chinese specifications:\n${missing.join('\n')}`)
+    if (invalid.length) console.error(`Invalid Chinese source notices:\n${invalid.join('\n')}`)
+    process.exitCode = 1
+  } else {
+    console.log(`Verified ${englishFiles.length} English/Chinese specification pairs.`)
   }
 }
 
-if (missing.length || invalid.length) {
-  if (missing.length) console.error(`Missing Chinese specifications:\n${missing.join('\n')}`)
-  if (invalid.length) console.error(`Invalid Chinese source notices:\n${invalid.join('\n')}`)
-  process.exitCode = 1
-} else {
-  console.log(`Verified ${englishFiles.length} English/Chinese specification pairs.`)
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main()
 }

--- a/docs/scripts/check-locales.test.mjs
+++ b/docs/scripts/check-locales.test.mjs
@@ -1,0 +1,23 @@
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { test } from 'node:test'
+import { noticeRoute, verifyLocalePairs } from './check-locales.mjs'
+
+test('notice routes keep POSIX separators on every platform', () => {
+  // `markdownFiles` builds its paths with `path.relative`, which separates with
+  // backslashes on Windows. The notice is a routed link, so a backslash there
+  // makes every Chinese mirror look like it is missing its source notice.
+  const relative = ['01-product', '00-overview.md'].join(path.sep)
+
+  assert.equal(noticeRoute(relative), '/spec/01-product/00-overview')
+  assert.equal(noticeRoute('03-runtime/01-ipc-protocol.md'), '/spec/03-runtime/01-ipc-protocol')
+  assert.ok(!noticeRoute(relative).includes('\\'))
+})
+
+test('every English specification has a valid Chinese mirror', () => {
+  const { englishFiles, missing, invalid } = verifyLocalePairs()
+
+  assert.ok(englishFiles.length > 0, 'expected to discover English specifications')
+  assert.deepEqual(missing, [], 'Chinese specifications missing for the listed English pages')
+  assert.deepEqual(invalid, [], 'Chinese pages whose source notice or structure is invalid')
+})


### PR DESCRIPTION
Fixes #201.

## Summary

`pnpm docs:check` fails on Windows and passes on the Linux CI runner. The check builds the required source-notice route from a `path.relative` result, which separates with backslashes on Windows, so it looks for `/spec/01-product\00-overview` while the Chinese mirror links `/spec/01-product/00-overview`.

## Cause

```js
const englishRoute = `/spec/${relativePath.replace(/\.md$/, '')}`
```

On Windows `relativePath` is `01-product\00-overview.md`. The mirror contains the POSIX route:

```markdown
> **翻译说明：** 本页是与 [英文源规格](/spec/01-product/00-overview) 一一对应的机器辅助翻译。
```

so `source.includes(...)` never matches and every nested page is reported invalid. The three pages directly under `docs/spec` (`00-baseline.md`, `NAV.md`, `README.md`) have no separator and pass; the reported list contains exactly the other 74 files, which is the signature of the bug.

## Reproduction

Windows, on `main` at `6e6d710e`:

```
$ node docs/scripts/check-locales.mjs
Invalid Chinese source notices:
01-product\00-overview.md
... (74 entries)
$ echo $?
1
```

With this change:

```
$ node docs/scripts/check-locales.mjs
Verified 77 English/Chinese specification pairs.
$ echo $?
0
```

## Changes

- `docs/scripts/check-locales.mjs`: normalize separators when assembling the notice route; split the check into `noticeRoute` and `verifyLocalePairs`, with the CLI body behind a `main()` guard so importing the module no longer runs the scan. Messages and exit codes are unchanged.
- `docs/scripts/check-locales.test.mjs`: covers the route normalization and the pair scan.
- `docs/package.json`: adds `"test": "node --test"`.

## Validation

- `node docs/scripts/check-locales.mjs` — exit 1 before, exit 0 after (77 pairs verified).
- `node --test` in `docs/` — 2 tests pass. Against the unfixed script the suite fails, so it is bound to the fix.
- `node scripts/check-release-docs.mjs` — unaffected by this change (verified separately).
- `git diff --check` — clean; `git ls-files --eol` reports `w/lf` for the spec pages, so this is not a line-ending problem.

## Notes for the maintainer

- The new `test` script uses Node's built-in runner, so it adds no dependency. `ci.yml` already runs `pnpm -r --if-present test`, which will now include the `docs` package; if you would rather keep the docs workspace out of that job, drop the script and keep the test file. No workflow file is modified.
- The route assertion is only a regression guard on Windows: on Linux (`path.sep === '/'`) the normalization is a no-op and the test passed before the fix as well. The assertion that fails on every platform is the import of `noticeRoute`, since the unfixed script does not export it.
- Worth considering separately: `ci.yml` ignores `docs/**`, so only the `docs-check` workflow covers this path, and that workflow runs solely on `ubuntu-latest` — which is why a Windows-only failure can stay invisible. I have not changed any workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
