### PR TITLE
fix(desktop): show the vision badge from the binding's image override

### DIFF
--- a/apps/desktop/src/components/Composer.tsx
+++ b/apps/desktop/src/components/Composer.tsx
@@ -2530,7 +2530,7 @@ export function Composer({
                                               {optionTitle}
                                             </span>
                                             <span className="composer-model-option-meta">
-                                              {composerModelBadges(model).map(
+                                              {composerModelBadges(model, group.provider).map(
                                                 (badge) => (
                                                   <span
                                                     key={badge}

--- a/apps/desktop/src/lib/composer-models.ts
+++ b/apps/desktop/src/lib/composer-models.ts
@@ -1,6 +1,8 @@
 import {
+  bindingSupportsImages,
   modelIdsMatch,
   modelMatchesFilter,
+  type ModelBinding,
   type ModelInfo,
   type ProviderPublic,
 } from "@pi-desktop/shared";
@@ -56,26 +58,44 @@ export function composerModelDisplayName(
   modelId: string,
   fallback?: string,
 ): string {
+  const alias = composerModelBinding(provider, modelId)?.alias?.trim();
+  return alias || fallback?.trim() || modelId;
+}
+
+/**
+ * The provider's configured binding for a model, matched the same tolerant way
+ * as the display name so a namespaced or regional ID still finds its settings.
+ */
+export function composerModelBinding(
+  provider: ConfiguredProvider,
+  modelId: string,
+): ModelBinding | undefined {
   const normalizedModelId = modelId.trim().toLowerCase();
   const bindings = provider.models ?? [];
-  const binding =
+  return (
     bindings.find((candidate) => candidate.id.trim().toLowerCase() === normalizedModelId) ??
-    bindings.find((candidate) => modelIdsMatch(candidate.id, modelId));
-  const alias = binding?.alias?.trim();
-  return alias || fallback?.trim() || modelId;
+    bindings.find((candidate) => modelIdsMatch(candidate.id, modelId))
+  );
 }
 
 /** Short capability markers shown on a composer model row. */
 export type ComposerModelBadge = "reasoning" | "vision";
 
 /**
- * Published capability markers for one configured model. The composer shows
- * these so a model can be chosen on capability rather than on name alone.
+ * Capability markers for one configured model. The composer shows these so a
+ * model can be chosen on capability rather than on name alone. Vision follows
+ * the effective image input: the binding's Advanced "Image input" override
+ * when set, the published capability otherwise, the same answer the transport
+ * gate and the settings switch give (#214).
  */
-export function composerModelBadges(model: ModelInfo): ComposerModelBadge[] {
+export function composerModelBadges(
+  model: ModelInfo,
+  provider?: ConfiguredProvider | null,
+): ComposerModelBadge[] {
   const badges: ComposerModelBadge[] = [];
   if (modelMatchesFilter(model, "reasoning")) badges.push("reasoning");
-  if (modelMatchesFilter(model, "vision")) badges.push("vision");
+  const binding = provider ? composerModelBinding(provider, model.modelId) : undefined;
+  if (bindingSupportsImages(binding, model)) badges.push("vision");
   return badges;
 }
 

--- a/apps/desktop/test/composer-models.test.mjs
+++ b/apps/desktop/test/composer-models.test.mjs
@@ -161,6 +161,40 @@ test("composer model rows expose published reasoning and vision markers", () => 
   );
 });
 
+test("composer vision marker follows the binding's image-input override (#214)", () => {
+  const textOnly = {
+    modelId: "grok-auto",
+    displayName: "grok-auto",
+    providerId: "relay",
+    capabilities: ["text"],
+  };
+  const visionModel = {
+    modelId: "grok-4.5",
+    displayName: "Grok 4.5",
+    providerId: "relay",
+    capabilities: ["text", "vision"],
+    modalities: { input: ["text", "image"], output: ["text"] },
+  };
+  const provider = {
+    id: "relay",
+    models: [
+      { ...binding("grok-auto"), supportsImages: true },
+      { ...binding("grok-4.5"), supportsImages: false },
+    ],
+  };
+  // Settings → model → Advanced → Image input checked on a model discovered as text-only.
+  assert.deepEqual(composerModelBadges(textOnly, provider), ["vision"]);
+  // ...and unchecked on a model published as vision-capable.
+  assert.deepEqual(composerModelBadges(visionModel, provider), []);
+  // No override (or no binding at all): the published capability decides, as before.
+  assert.deepEqual(
+    composerModelBadges(visionModel, { id: "relay", models: [binding("grok-4.5")] }),
+    ["vision"],
+  );
+  assert.deepEqual(composerModelBadges(textOnly, { id: "relay", models: [] }), []);
+  assert.deepEqual(composerModelBadges(visionModel), ["vision"]);
+});
+
 test("composer model search matches id, name, family and provider", () => {
   const model = {
     modelId: "claude-opus-4-6",


### PR DESCRIPTION
Refs #214 (the picker half; see below for the transport half).

**Problem.** The composer model picker derived its 视觉 / vision badge from the published `ModelInfo` capabilities only (`composerModelBadges` → `modelMatchesFilter(model, "vision")`). A custom OpenAI-compatible model whose discovery cached `capabilities_json = ["text"]` therefore never showed the badge, even after Settings → model → Advanced → **Image input** was enabled (`supportsImages: true` in the binding), while a discovered vision model on another endpoint did. `listModels`'s `decorate()` deliberately keeps the published modalities unshaped by the binding (the settings panel compares its checkboxes against them), so the picker has to apply the override itself.

**Change.**
- `composerModelBadges(model, provider?)` resolves vision through the existing `bindingSupportsImages(binding, model)` helper: the binding's override when set, the published capability otherwise. Reasoning is unchanged.
- The binding lookup that `composerModelDisplayName` already used (exact id, then `modelIdsMatch`) is factored into `composerModelBinding(provider, modelId)` and reused.
- `Composer.tsx` passes `group.provider` at the one call site.

**Transport half of #214.** On current `main` the attachment gate already follows the override: `supportsVision = visionFromModelConfig(launch.sidecarParams.provider.modelConfig)` with the binding applied through `modelConfigWithBinding`, so pasted images are sent as `image_url` once the checkbox is on. The report is against 0.14.6; if you can still reproduce the `@path` fallback on a current build, that would be a separate bug.

**Tests.** `apps/desktop/test/composer-models.test.mjs` adds a case: override on a text-only model shows the badge, override off on a vision model hides it, no override (or no binding) keeps the published answer. `node --test apps/desktop/test/composer-models.test.mjs` → 11 pass (the new case fails on `main`); `tsc -p apps/desktop/tsconfig.json --noEmit` clean.
