### PR TITLE
fix: stop consuming OpenAI Responses stream after the terminal event

### DIFF
--- a/docs/spec/03-runtime/11-provider-model-system.md
+++ b/docs/spec/03-runtime/11-provider-model-system.md
@@ -610,6 +610,19 @@ model-level pin the provider-wide style applies unchanged.
 
 This is the **universal escape hatch** guaranteeing market coverage beyond native integrations.
 
+### 16.1 Responses stream termination (pi-ai patch)
+
+The OpenAI Responses adapter must treat `response.completed` (and
+`response.incomplete`) as the end of the stream: after finalizing the
+response, it stops consuming the stream instead of awaiting the server's
+TCP FIN. Upstream pi-ai keeps iterating until the server closes the
+connection, which hangs the turn behind reverse proxies that hold the idle
+connection open. Until the fix ships upstream, `patches/` carries a pnpm
+patch on `@earendil-works/pi-ai@0.85.1` that breaks the event loop on the
+terminal event (the OpenAI SDK aborts the underlying request when the
+consumer stops iterating). Drop the patch once a pi-ai release includes the
+fix.
+
 ## 17. Multi-provider product rules
 
 1. Multiple providers of the same `vendorKey` are allowed and independent (for

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -660,6 +660,29 @@ Each scenario is documented in this format:
 - **Status**: Unit-covered (preset matching, catalog aliases, Completions
   compat); rendered UI scenario Draft
 
+#### E2E-248: Responses turn completes without waiting for the server to close the connection
+
+- **Preconditions**: A provider whose model pins `api: "openai-responses"` (or
+  a provider with `apiStyle: "responses"`) is configured; the endpoint is
+  fronted by a proxy that holds the HTTP connection open after the final
+  SSE event (a local reverse proxy or a stub server that never sends FIN).
+- **Steps**: 1) Start a session with that model and send a short prompt. 2)
+  Capture the SSE frames and confirm the server emitted
+  `response.completed` with `status: "completed"` and usage. 3) Keep the
+  stub/proxy connection open without sending a TCP FIN. 4) Observe the
+  assistant turn state and send a follow-up prompt.
+- **Expected**: The turn completes as soon as `response.completed` is
+  finalized: usage is recorded, `stopReason` is `stop`, and the client stops
+  consuming the stream (the underlying request is aborted) instead of
+  blocking on the idle connection. The composer becomes idle immediately and
+  the follow-up turn starts normally. The stream must not hang when the
+  server never closes the connection.
+- **Specs linked**: `03-runtime/11-provider-model-system.md` (§16.1)
+- **Acceptance**: B (provider Responses compatibility)
+- **Milestone**: M2
+- **Status**: Unit-covered (stream processor terminates on the terminal
+  event via the pi-ai patch); live-proxy scenario Draft
+
 #### E2E-005E: DeepSeek thinking replay includes reasoning_content on aggregator endpoints
 
 - **Preconditions**: An OpenAI-compatible provider whose base URL is not

--- a/docs/zh-CN/spec/03-runtime/11-provider-model-system.md
+++ b/docs/zh-CN/spec/03-runtime/11-provider-model-system.md
@@ -542,6 +542,17 @@ UI 可能会显示层级提示，但默认情况下不得硬阻止未知模型�
 
 目录条目还可以额外固定模型级 wire API（例如 `api: "openai-responses"`）。存在时它优先于 provider 级 `apiStyle`，因此 `opencode_go` 下的 responses-only 模型会走 Responses adapter 而非 Chat Completions；没有模型级固定时保持 provider 级风格不变。
 
+### 16.1 Responses 流终止（pi-ai 补丁）
+
+OpenAI Responses 适配器必须把 `response.completed`（以及
+`response.incomplete`）视为流的终点：完成响应收尾后即停止消费流，
+而不是继续等待服务端的 TCP FIN。上游 pi-ai 会一直迭代直到服务端关闭
+连接，在保持空闲连接不关的反向代理后面会导致整个回合挂起。在该修复
+随上游发布之前，`patches/` 通过 pnpm patch 修改
+`@earendil-works/pi-ai@0.85.1`，在终态事件处跳出事件循环（消费方停止
+迭代时 OpenAI SDK 会中止底层请求）。待 pi-ai 发布包含该修复的版本后
+移除补丁。
+
 ## 17. 多提供商产品规则
 
 1. 允许多个提供商具有相同的供应商密钥（例如两个 OpenRouter 帐户）。

--- a/packages/agent-runtime/src/responses-stream-termination.test.ts
+++ b/packages/agent-runtime/src/responses-stream-termination.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "vitest";
+import type { Context, Model } from "@earendil-works/pi-ai";
+import { stream } from "@earendil-works/pi-ai/api/openai-responses";
+
+const model: Model<"openai-responses"> = {
+  id: "responses-test",
+  name: "Responses Test",
+  api: "openai-responses",
+  provider: "acme",
+  baseUrl: "https://api.acme.test/v1",
+  reasoning: false,
+  input: ["text"],
+  cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  contextWindow: 128000,
+  maxTokens: 4096,
+};
+
+const context: Context = {
+  messages: [{ role: "user", content: "hi", timestamp: Date.now() }],
+};
+
+const completedEvent = {
+  type: "response.completed",
+  sequence_number: 2,
+  response: {
+    object: "response",
+    id: "resp_1",
+    created_at: 1,
+    model: "responses-test",
+    output: [
+      {
+        id: "item_1",
+        type: "message",
+        role: "assistant",
+        content: [{ type: "output_text", text: "hello" }],
+        status: "completed",
+      },
+    ],
+    status: "completed",
+    usage: {
+      input_tokens: 5,
+      input_tokens_details: { cached_tokens: 0 },
+      output_tokens: 2,
+      output_tokens_details: { reasoning_tokens: 0 },
+      total_tokens: 7,
+    },
+  },
+  output_index: 0,
+};
+
+/** SSE body that emits the terminal event and then never ends. */
+function hangAfterTerminalBody(): ReadableStream<Uint8Array> {
+  const encoder = new TextEncoder();
+  return new ReadableStream({
+    start(controller) {
+      controller.enqueue(
+        encoder.encode(
+          `event: response.created\ndata: ${JSON.stringify({ type: "response.created", sequence_number: 0, response: { id: "resp_1" } })}\n\n`,
+        ),
+      );
+      controller.enqueue(
+        encoder.encode(
+          `event: response.output_text.delta\ndata: ${JSON.stringify({ type: "response.output_text.delta", sequence_number: 1, output_index: 0, content_index: 0, delta: "hello" })}\n\n`,
+        ),
+      );
+      controller.enqueue(
+        encoder.encode(`event: response.completed\ndata: ${JSON.stringify(completedEvent)}\n\n`),
+      );
+      // Terminal event delivered; never enqueue again and never close().
+    },
+  });
+}
+
+describe("OpenAI Responses stream termination (issue #130)", () => {
+  it("completes the turn without waiting for the server to close the connection", async () => {
+    const streamBody = hangAfterTerminalBody();
+    const fetchImpl = async () =>
+      new Response(streamBody, {
+        status: 200,
+        headers: { "content-type": "text/event-stream" },
+      });
+
+    const events = await stream(model, context, { apiKey: "sk-test", fetch: fetchImpl as any });
+    const seen: string[] = [];
+    // Reading to completion must not hang: with the fix the stream consumer
+    // stops after the terminal event, so `result()` resolves promptly.
+    const result = await Promise.race([
+      events.result(),
+      new Promise<never>((_, reject) =>
+        setTimeout(() => reject(new Error("stream hung after response.completed")), 5000),
+      ),
+    ]);
+
+    for await (const event of events) {
+      seen.push(event.type);
+    }
+
+    expect(seen).toContain("done");
+    expect(result.stopReason).toBe("stop");
+    expect(result.usage.totalTokens).toBe(7);
+  }, 10000);
+});

--- a/patches/@earendil-works__pi-ai@0.85.1.patch
+++ b/patches/@earendil-works__pi-ai@0.85.1.patch
@@ -1,0 +1,15 @@
+diff --git a/dist/api/openai-responses-shared.js b/dist/api/openai-responses-shared.js
+index 43e463dbfd1e6cc437ebc680468036f47678de26..364c8c0426d12543c1b64daa8e6eaa22f35f6f60 100644
+--- a/dist/api/openai-responses-shared.js
++++ b/dist/api/openai-responses-shared.js
+@@ -636,6 +636,10 @@ export async function processResponsesStream(openaiStream, output, stream, model
+         }
+         else if (event.type === "response.completed" || event.type === "response.incomplete") {
+             finalizeResponse(event.response);
++            // The response is fully delivered: stop consuming the stream so the
++            // request does not hang when the server (or a reverse proxy) never
++            // closes the connection after the terminal event.
++            break;
+         }
+         else if (event.type === "error") {
+             throw new Error(`Error Code ${event.code}: ${event.message}` || "Unknown error");

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ overrides:
   js-yaml@4: '>=4.3.1 <5'
   vite@5: '>=6.4.3 <7'
 
+patchedDependencies:
+  '@earendil-works/pi-ai@0.85.1': d5f5bb308c045076374ad6aac19483a00c2c12258cf39d7b3f9c0ba1bf4d5503
+
 importers:
 
   .:
@@ -30,7 +33,7 @@ importers:
     devDependencies:
       '@earendil-works/pi-ai':
         specifier: 0.85.1
-        version: 0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        version: 0.85.1(patch_hash=d5f5bb308c045076374ad6aac19483a00c2c12258cf39d7b3f9c0ba1bf4d5503)(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@pi-desktop/agent-host':
         specifier: workspace:*
         version: link:../../packages/agent-host
@@ -163,7 +166,7 @@ importers:
         version: 0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-ai':
         specifier: 0.85.1
-        version: 0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+        version: 0.85.1(patch_hash=d5f5bb308c045076374ad6aac19483a00c2c12258cf39d7b3f9c0ba1bf4d5503)(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@pi-desktop/shared':
         specifier: workspace:*
         version: link:../shared
@@ -4561,7 +4564,7 @@ snapshots:
   '@earendil-works/pi-agent-core@0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@earendil-works/chord': 0.85.1
-      '@earendil-works/pi-ai': 0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.85.1(patch_hash=d5f5bb308c045076374ad6aac19483a00c2c12258cf39d7b3f9c0ba1bf4d5503)(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-telemetry': 0.85.1
       diff: 8.0.4
       ignore: 7.0.5
@@ -4575,7 +4578,7 @@ snapshots:
       - ws
       - zod
 
-  '@earendil-works/pi-ai@0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
+  '@earendil-works/pi-ai@0.85.1(patch_hash=d5f5bb308c045076374ad6aac19483a00c2c12258cf39d7b3f9c0ba1bf4d5503)(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)':
     dependencies:
       '@anthropic-ai/sdk': 0.123.0(zod@4.4.3)
       '@aws-sdk/client-bedrock-runtime': 3.1048.0
@@ -4599,7 +4602,7 @@ snapshots:
     dependencies:
       '@earendil-works/chord': 0.85.1
       '@earendil-works/pi-agent-core': 0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.85.1(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
+      '@earendil-works/pi-ai': 0.85.1(patch_hash=d5f5bb308c045076374ad6aac19483a00c2c12258cf39d7b3f9c0ba1bf4d5503)(supports-color@7.2.0)(ws@8.21.1)(zod@4.4.3)
       '@earendil-works/pi-tui': 0.85.1
       '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,3 +42,5 @@ minimumReleaseAgeExclude:
   - '@earendil-works/pi-agent-core@0.85.1'
   - '@earendil-works/pi-ai@0.85.1'
   - '@earendil-works/pi-telemetry@0.85.1'
+patchedDependencies:
+  '@earendil-works/pi-ai@0.85.1': patches/@earendil-works__pi-ai@0.85.1.patch


### PR DESCRIPTION
Fixes #130

## Problem

When talking to an OpenAI Responses-compatible endpoint, the client keeps consuming the SSE stream after receiving `response.completed`. Upstream `@earendil-works/pi-ai@0.85.1` (`processResponsesStream` in `openai-responses-shared.js`) only finishes when the server closes the connection. If the backend or a reverse proxy (e.g. Nginx) holds the idle connection open instead of sending a TCP FIN, the turn hangs forever and the agent cannot continue.

## Fix

Add a pnpm patch on `@earendil-works/pi-ai@0.85.1` that breaks out of the event loop right after `finalizeResponse` runs for `response.completed` / `response.incomplete`. The consumer stops iterating, the OpenAI SDK aborts the underlying request, and the turn completes immediately without depending on the server closing the connection.

The Codex Responses adapter already returns on the terminal event, so it is unaffected.

## Test

- New regression test `responses-stream-termination.test.ts`: a stub fetch returns an SSE body that emits `response.completed` and then never ends; the stream resolves with `stopReason: "stop"` and correct usage instead of hanging.
- `packages/agent-runtime`: 27 test files / 348 tests pass.

The patch can be dropped once a pi-ai release ships the fix upstream.