### PR TITLE
fix: 修复运行结束后排队消息无法自动发送的问题

### DIFF
--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -5311,18 +5311,16 @@ function finishTurn(
   })();
 
   turnFinalizations.set(sessionId, finalization);
-  void finalization.then(
-    () => {
-      if (turnFinalizations.get(sessionId) === finalization) {
-        turnFinalizations.delete(sessionId);
-      }
-    },
-    () => {
-      if (turnFinalizations.get(sessionId) === finalization) {
-        turnFinalizations.delete(sessionId);
-      }
-    },
-  );
+  const releaseFinalization = () => {
+    if (turnFinalizations.get(sessionId) === finalization) {
+      turnFinalizations.delete(sessionId);
+      // The terminal event reaches Agent Host while activeTurns still owns
+      // this session. Retry its deferred queue drain once settlement releases
+      // both busy guards, unless the application is shutting down.
+      if (!quitting) agentHostBridge?.agentHost.kick(sessionId);
+    }
+  };
+  void finalization.then(releaseFinalization, releaseFinalization);
   return finalization;
 }
 
@@ -9487,7 +9485,7 @@ app.whenReady().then(async () => {
     invoke: invokeIpc,
     channels: IPC.invoke,
     getHost: () => host,
-    isSessionBusy: (sessionId) => activeTurns.has(sessionId),
+    isSessionBusy: (sessionId) => activeTurns.has(sessionId) || turnFinalizations.has(sessionId),
     onQueueChange: (event) => sendToRenderer(IPC.event.agentQueueChanged, event),
     log: (level, message, data) => logger.app("runtime", level, message, { data }),
   });

--- a/apps/desktop/test/queued-turn-finalization.test.mjs
+++ b/apps/desktop/test/queued-turn-finalization.test.mjs
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import { setImmediate } from "node:timers/promises";
+import { runInNewContext } from "node:vm";
+import test from "node:test";
+import ts from "typescript";
+import { IPC } from "@pi-desktop/shared";
+import { createAgentHostBridge } from "../electron/main/agent-host-bridge.ts";
+
+// Exercise the actual desktop finalizer with the real bridge and Agent Host,
+// without booting Electron or making a provider request.
+const main = await readFile(new URL("../electron/main/index.ts", import.meta.url), "utf8");
+const start = main.indexOf("function finishTurn(");
+const end = main.indexOf("async function finishApprovedExecution(", start);
+assert.ok(start >= 0 && end > start);
+const finalizer = ts.transpileModule(main.slice(start, end), {
+  compilerOptions: { target: ts.ScriptTarget.ES2022 },
+}).outputText;
+
+function deferred() {
+  let resolve;
+  let reject;
+  const promise = new Promise((yes, no) => { resolve = yes; reject = no; });
+  return { promise, resolve, reject };
+}
+
+function fixture() {
+  const activeTurns = new Map([["s1", "initial"]]);
+  const turnFinalizations = new Map();
+  const persistedQueue = new Map();
+  const prompts = [];
+  const writes = [];
+  const context = {
+    activeTurns,
+    turnFinalizations,
+    activeTurnUsages: new Map(),
+    planSubmissionTurnIds: new Set(),
+    turnSettlements: new Map(),
+    scheduledRunsBySession: new Map(),
+    activeToolCalls: new Map(),
+    planSubmissionTurnKey: (sessionId, turnId) => `${sessionId}:${turnId}`,
+    shouldCreateTaskNotification: () => false,
+    logger: { app() {} },
+    setTimeout: () => ({ unref() {} }),
+    quitting: false,
+  };
+  const host = {
+    async call(method, params) {
+      if (method === "session.get") {
+        return { session: { id: params.id, permissionMode: "ask" } };
+      }
+      if (method === "session.queuePush") {
+        persistedQueue.set(params.id, params);
+        return {};
+      }
+      if (method === "session.queueRemove") {
+        return { removed: persistedQueue.delete(params.id) };
+      }
+      if (method === "session.endTurn") {
+        const write = deferred();
+        writes.push({ ...write, turnId: params.turnId });
+        return write.promise;
+      }
+      throw new Error(`Unexpected host call: ${method}`);
+    },
+  };
+  const bridge = createAgentHostBridge({
+    channels: IPC.invoke,
+    getHost: () => host,
+    isSessionBusy: (id) => activeTurns.has(id) || turnFinalizations.has(id),
+    log() {},
+    async invoke(channel, [request]) {
+      assert.equal(channel, IPC.invoke.agentPrompt);
+      assert.equal(activeTurns.has(request.sessionId), false, "previous turn must release ownership");
+      assert.equal(turnFinalizations.has(request.sessionId), false, "finalization must settle before dispatch");
+      prompts.push(request);
+      const turnId = `runtime-${prompts.length}`;
+      activeTurns.set(request.sessionId, turnId);
+      bridge.ingest({ sessionId: request.sessionId, turnId, ts: Date.now(), event: { type: "agent_start" } });
+      return { accepted: true, turnId };
+    },
+  });
+  Object.assign(context, { host, agentHostBridge: bridge });
+  const finishTurn = runInNewContext(`${finalizer}\nfinishTurn;`, context);
+  bridge.ingest({ sessionId: "s1", turnId: "initial", ts: Date.now(), event: { type: "agent_start" } });
+
+  function finish(status = "completed") {
+    const turnId = activeTurns.get("s1");
+    if (status === "aborted") bridge.markAborting("s1");
+    bridge.ingest({
+      sessionId: "s1", turnId, ts: Date.now(),
+      event: status === "error"
+        ? { type: "error", error: { code: "PROVIDER_ERROR", message: "Fixture failure", retriable: false } }
+        : { type: "agent_end", messageIds: [] },
+    });
+    return finishTurn("s1", status);
+  }
+  return { bridge, context, activeTurns, turnFinalizations, persistedQueue, prompts, writes, finish, finishTurn };
+}
+
+for (const status of ["completed", "error", "aborted"]) {
+  test(`queued prompts resume once, in FIFO order, after ${status} turn finalization`, async () => {
+    const f = fixture();
+    await f.bridge.queue.push({ sessionId: "s1", content: "first follow-up" });
+    await f.bridge.queue.push({ sessionId: "s1", content: "second follow-up" });
+    f.activeTurns.set("s2", "other-session");
+    await f.bridge.queue.push({ sessionId: "s2", content: "unrelated follow-up" });
+
+    const pending = f.finish(status);
+    assert.equal(f.finish(status), pending, "duplicate terminal handling must share the same write");
+    await setImmediate();
+    assert.equal(f.writes.length, 1);
+    assert.equal(f.prompts.length, 0, "terminal event must not bypass durable finalization");
+    assert.equal(f.persistedQueue.size, 3);
+
+    f.writes[0].resolve({ ok: true });
+    await pending;
+    await setImmediate();
+    assert.deepEqual(f.prompts.map((p) => p.content), ["first follow-up"]);
+    assert.equal(f.bridge.queue.list("s1").length, 1);
+    assert.equal(f.bridge.queue.list("s2").length, 1);
+    assert.equal(f.persistedQueue.size, 2);
+
+    const next = f.finish();
+    await setImmediate();
+    assert.equal(f.prompts.length, 1, "remaining queue must wait for the next turn too");
+    f.writes[1].resolve({ ok: true });
+    await next;
+    await setImmediate();
+    assert.deepEqual(f.prompts.map((p) => p.content), ["first follow-up", "second follow-up"]);
+    assert.equal(f.bridge.queue.list("s1").length, 0);
+    assert.equal(f.persistedQueue.size, 1);
+  });
+}
+
+test("a settled persistence failure does not leave the queue asleep", async () => {
+  const f = fixture();
+  await f.bridge.queue.push({ sessionId: "s1", content: "follow-up" });
+  const pending = f.finish();
+  f.writes[0].reject(new Error("Fixture persistence failure"));
+  await pending;
+  await setImmediate();
+  assert.equal(f.prompts.length, 1);
+  assert.equal(f.turnFinalizations.size, 0);
+});
+
+test("turn finalization during app shutdown preserves queued work without starting it", async () => {
+  const f = fixture();
+  await f.bridge.queue.push({ sessionId: "s1", content: "follow-up" });
+  const pending = f.finish();
+  f.context.quitting = true;
+  f.writes[0].resolve({ ok: true });
+  await pending;
+  await setImmediate();
+  assert.equal(f.prompts.length, 0);
+  assert.equal(f.persistedQueue.size, 1);
+  assert.equal(f.turnFinalizations.size, 0);
+});

--- a/docs/spec/02-architecture/05-remote-agent-control.md
+++ b/docs/spec/02-architecture/05-remote-agent-control.md
@@ -374,7 +374,10 @@ Host   -> next queued turn starts
 `turn/start` is an admission call. It returns quickly with a `turnId`; it must
 not hold an HTTP request open until model execution ends. With
 `admission: "queue"` the Host places the turn in its per-session queue and
-releases it after the active turn's terminal event; the queue is Host state,
+releases it after the active turn's terminal event and durable finalization;
+when terminal-event draining observes a busy runtime, the desktop must wake
+the queue again after releasing turn ownership and its finalization guard.
+Shutdown does not wake queued work. The queue is Host state,
 persisted by host-core, restored after a restart, and held until a controller
 attaches, so the local desktop and every remote client see the same pending
 prompts.

--- a/docs/spec/04-ux/09-interaction-patterns.md
+++ b/docs/spec/04-ux/09-interaction-patterns.md
@@ -642,18 +642,24 @@ may be retained while exactly one workspace supplies the visible shell context.
 
 ### 3.4 Queued send
 
-- While a session is running, Send remains enabled alongside Abort. Accepted
-  prompts clear the composer and append to that session's renderer-local FIFO
-  queue; session switching never moves or clears another session's queue.
+- While a session is running, the composer shows Send when the draft has
+  content and Stop when it is empty. Accepted prompts clear the composer and
+  append to that session's Host-owned, persisted FIFO queue; session switching
+  never moves or clears another session's queue.
 - The queue renders above the composer. Each row has an independently
   keyboard-reachable Remove action and a Send now action.
 - Send now moves its row to the head and requests the new `agent/stop` channel.
   The current assistant response and completed tool batch finish normally;
-  after `agent_end`, the promoted row is dispatched through the normal
-  `agent/prompt` flow before the remaining rows. An idle Send now dispatches
-  immediately.
-- Abort remains immediate and never clears the queue. Queued prompts are
-  intentionally lost on application restart because the queue is not durable.
+  after `agent_end` and durable turn finalization, the promoted row is
+  dispatched through the normal `agent/prompt` flow before the remaining rows.
+  An idle Send now dispatches immediately.
+- Without Send now, the next FIFO row starts automatically after the active
+  turn completes, fails, or is aborted. A terminal event can arrive before
+  persistence releases the session; finalization must wake the queue again
+  after releasing ownership. No additional send or session switch is required.
+- Abort remains immediate and never clears the queue. Queued prompts survive
+  application restart and remain held until a controller attaches (ADR 0213).
+  Finalization during application shutdown must not start another queued turn.
 
 ## 3A. Context checkpoint lifecycle
 

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -1077,7 +1077,11 @@ Each scenario is documented in this format:
   in B, then return to A before either run completes. 5) Choose Send now on A's
   remaining queued row. 6) Observe A through the current tool/reply boundary
   and then the next turn. 7) Start another run in A, clear the draft to expose
-  the single Stop button, press Stop, and inspect the queue.
+  the single Stop button, press Stop, and inspect the queue. 8) Repeat with
+  two queued prompts, let the active turn finish without Send now, and delay
+  its host `session.endTurn` response until after `agent_end` is delivered.
+  Release finalization and observe both follow-ups through their turn
+  boundaries. Repeat with a provider error and an immediate abort.
 - **Expected**: The single submit slot contains exactly one button in every
   state: disabled Send while idle and empty, enabled Send while running with
   content (which queues the prompt), and Stop while running with an empty
@@ -1086,13 +1090,21 @@ Each scenario is documented in this format:
   current batch completes with a normal `agent_end`/completed turn, then the
   selected row starts before any remaining FIFO rows without `AGENT_BUSY`.
   Immediate Stop aborts the current reply and preserves A's queued row;
-  switching sessions preserves both queues.
+  switching sessions preserves both queues. Ordinary completion, provider
+  failure, and abort all resume queued sending automatically after durable
+  finalization releases the session. No queued prompt starts while finalization
+  is pending; each subsequent turn starts once in FIFO order, without another
+  click or session switch. Repeated terminal handling does not double-dispatch.
+  Other sessions' queues remain unchanged, and quitting while finalization is
+  pending preserves queued work without starting another turn.
 - **Specs linked**: `03-runtime/01-ipc-protocol.md` (§5.2),
   `04-ux/08-component-spec.md` (§11),
-  `04-ux/09-interaction-patterns.md` (§3.4), ADR 0118
+  `04-ux/09-interaction-patterns.md` (§3.4), ADR 0118, ADR 0213
 - **Acceptance**: C (chat, stream, and session isolation), Quality
 - **Milestone**: M6+
-- **Status**: Source-level regression covered; full UI scenario Draft
+- **Status**: Source-level regression and deterministic desktop finalization /
+  Agent Host integration covered (`queued-turn-finalization.test.mjs`); full
+  UI scenario Draft
 
 #### E2E-011g: New Task does not leave the previous transcript on screen
 


### PR DESCRIPTION
运行中追加的消息已经持久化进入队列，但当前轮结束后不会自动发送。原因是结束事件触发队列调度时，会话仍被收尾流程占用；持久化完成并释放会话后，没有再次唤醒队列。

本次修复在收尾完成、清除会话占用后重新触发队列调度。正常完成、报错和中止后，追加消息都能按 FIFO 顺序继续发送；等待收尾期间不会提前启动，重复处理结束事件不会重复发送，应用退出时也不会启动新的排队任务。

- 同步队列架构说明、交互规格及 E2E-011f 场景。
- 新增确定性回归测试，延迟 `session.endTurn` 返回，覆盖连续排队、重复结束事件、会话隔离、持久化失败及退出场景。修复前 4 项失败，修复后全部通过。
- 验证通过：桌面相关测试 17 项、Agent Host 测试 34 项、依赖构建及桌面 TypeScript 类型检查。
- 按仓库规则未运行本地 E2E，也未手动触发远程 E2E。

Closes #243
