### PR TITLE
fix: 支持 Alt+Enter 即时 steering，保留 Enter 排队跟进

### DIFF
--- a/apps/desktop/electron/main/agent-steering.ts
+++ b/apps/desktop/electron/main/agent-steering.ts
@@ -1,0 +1,105 @@
+import {
+  ErrorCodes,
+  type AgentEventEnvelope,
+  type AgentPromptResponse,
+  type AgentSteerRequest,
+  type UiMessage,
+} from "@pi-desktop/shared";
+import { appendPromptFallbackPaths, durableUserMessageId, preparePromptAttachments } from "./prompt-attachments.ts";
+import type { HostProcess } from "./host-process.ts";
+import type { PersistenceOutbox } from "./persistence-outbox.ts";
+
+type Backend = {
+  call<T = unknown>(method: string, params?: Record<string, unknown>): Promise<T>;
+};
+
+type SteeringOptions = {
+  host: Backend | null;
+  sidecar: Backend | null;
+  dataDir: string;
+  activeTurn: (sessionId: string) => string | undefined;
+  isFinalizing: (sessionId: string) => boolean;
+};
+
+/** Admit input to the existing runtime after validating the active turn's attachments. */
+export async function steerActiveTurn(
+  req: AgentSteerRequest,
+  options: SteeringOptions,
+): Promise<AgentPromptResponse> {
+  const { host, sidecar, dataDir } = options;
+  if (!host || !sidecar) throw new Error("backend unavailable");
+  if (!req?.sessionId || typeof req.content !== "string" || !req.expectedTurnId ||
+      (!req.content.trim() && !req.attachments?.length)) {
+    throw Object.assign(new Error("Steering input and expectedTurnId required"), { errorCode: ErrorCodes.INVALID_ARGUMENT });
+  }
+  if (options.activeTurn(req.sessionId) !== req.expectedTurnId || options.isFinalizing(req.sessionId)) {
+    throw Object.assign(new Error("The target turn has ended"), { errorCode: ErrorCodes.TURN_NOT_FOUND });
+  }
+  const context = await sidecar.call<{ projectPath?: string; supportsVision: boolean }>(
+    "agent.steeringContext", { sessionId: req.sessionId, expectedTurnId: req.expectedTurnId },
+  );
+  const prepared = await preparePromptAttachments(
+    dataDir, req.sessionId, context.projectPath, req.attachments ?? [], context.supportsVision,
+  );
+  const session = await host.call<{ session?: { messages?: UiMessage[] } }>("session.get", {
+    id: req.sessionId, messageLimit: 1,
+  });
+  const message: UiMessage = {
+    id: durableUserMessageId(req.messageId, session.session?.messages ?? []),
+    role: "user", content: req.content, status: "complete", createdAt: new Date().toISOString(),
+    ...(prepared.length ? { attachments: prepared.map((attachment) => attachment.message) } : {}),
+  };
+  // Revalidate inside the runtime after all file/host IO. A stale target must
+  // never turn into a normal prompt or alter the next turn's configuration.
+  return sidecar.call<{ accepted: boolean; turnId: string }>("agent.steer", {
+    sessionId: req.sessionId, expectedTurnId: req.expectedTurnId, message,
+    content: appendPromptFallbackPaths(req.content, prepared),
+    attachments: prepared.filter((attachment) => attachment.inlineData).map((attachment) => ({
+      path: attachment.message.ref, name: attachment.message.name, kind: attachment.message.kind,
+      mimeType: attachment.message.mimeType, size: attachment.message.size, data: attachment.inlineData,
+    })),
+  });
+}
+
+/** Own provisional reply reservations and their persistence lifecycle. */
+export class SteeringTranscript {
+  private readonly reservedReplies = new Set<string>();
+  private readonly outbox: Pick<PersistenceOutbox, "enqueue">;
+  private readonly getHost: () => HostProcess | null;
+  private readonly onError: (message: string, sessionId: string, error: unknown) => void;
+
+  constructor(
+    outbox: Pick<PersistenceOutbox, "enqueue">,
+    getHost: () => HostProcess | null,
+    onError: (message: string, sessionId: string, error: unknown) => void,
+  ) {
+    this.outbox = outbox;
+    this.getHost = getHost;
+    this.onError = onError;
+  }
+
+  persistInput(envelope: AgentEventEnvelope, fallbackTurnId?: string): void {
+    const event = envelope.event;
+    if (event.type !== "message_end" || event.message.role !== "user" || envelope.parentToolCallId) return;
+    const persist = (message: UiMessage) => {
+      void this.outbox.enqueue({
+        key: `message:${envelope.sessionId}:${message.id}`,
+        sessionId: envelope.sessionId, message, turnId: envelope.turnId ?? fallbackTurnId,
+      }, this.getHost).catch((error) => this.onError("steering transcript enqueue failed", envelope.sessionId, error));
+    };
+    // Reserve the live reply's position; its final snapshot updates that row.
+    if (event.precedingAssistant?.role === "assistant") {
+      this.reservedReplies.add(event.precedingAssistant.id);
+      persist(event.precedingAssistant);
+    }
+    persist(event.message);
+  }
+
+  settleReply(messageId: string): boolean {
+    return this.reservedReplies.delete(messageId);
+  }
+
+  clear(): void {
+    this.reservedReplies.clear();
+  }
+}

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -69,6 +69,7 @@ import {
   normalizeMode,
   type AgentEventEnvelope,
   type AgentPromptRequest,
+  type AgentSteerRequest,
   type PromptEnhancementRequest,
   type SessionSummarizeTitleRequest,
   type AgentStopRequest,
@@ -2374,6 +2375,7 @@ async function importLegacyScheduled() {
 
 /** sessionId → open host turn id, for turn bookkeeping across agent events. */
 const activeTurns = new Map<string, string>();
+const steeringReservedReplies = new Set<string>();
 const sessionOperationTails = new Map<string, Promise<void>>();
 
 async function acquireSessionOperation(sessionId: string): Promise<() => void> {
@@ -4918,6 +4920,7 @@ function wireSidecar(s: AgentSidecar) {
     if (sidecar !== s) return;
     logger.flushChild("agent");
     sidecar = null;
+    steeringReservedReplies.clear();
     if (intentional || quitting) return;
     // A sidecar crash closes live approval waiters before the replacement
     // sidecar starts. This prevents an old renderer response from waking a
@@ -5699,6 +5702,25 @@ function persistAgentEvent(envelope: AgentEventEnvelope): UiMessage | undefined 
   if (event.type === "turn_end" && !envelope.parentToolCallId) {
     addActiveTurnUsage(envelope.sessionId, event.subagentUsage);
   }
+  if (event.type === "message_end" && event.message.role === "user" && !envelope.parentToolCallId) {
+    // Reserve the in-flight reply's existing UI position before appending input.
+    // The final assistant snapshot later updates this same transcript row.
+    if (event.precedingAssistant?.role === "assistant") {
+      steeringReservedReplies.add(event.precedingAssistant.id);
+      void persistenceOutbox.enqueue({
+        key: `message:${envelope.sessionId}:${event.precedingAssistant.id}`,
+        sessionId: envelope.sessionId, message: event.precedingAssistant, turnId: envelope.turnId ?? turnId,
+      }, () => host).catch((error) => logger.app("persistence", "warn", "steering checkpoint enqueue failed", {
+        sessionId: envelope.sessionId, data: String(error),
+      }));
+    }
+    void persistenceOutbox.enqueue({
+      key: `message:${envelope.sessionId}:${event.message.id}`,
+      sessionId: envelope.sessionId, message: event.message, turnId: envelope.turnId ?? turnId,
+    }, () => host).catch((error) => logger.app("persistence", "warn", "steering message persistence enqueue failed", {
+      sessionId: envelope.sessionId, data: String(error),
+    }));
+  }
   if (event.type === "message_end" && event.message.role === "assistant") {
     if (!envelope.parentToolCallId && event.message.usage) {
       addActiveTurnUsage(envelope.sessionId, event.message.usage);
@@ -5726,7 +5748,8 @@ function persistAgentEvent(envelope: AgentEventEnvelope): UiMessage | undefined 
     const empty =
       !(event.message.content || "").trim() &&
       !(event.message.thinking || "").trim();
-    if (failed && empty && !event.message.error) return;
+    const reservedForSteering = steeringReservedReplies.delete(event.message.id);
+    if (failed && empty && !event.message.error && !reservedForSteering) return;
     void persistenceOutbox
       .enqueue(
         {
@@ -8176,6 +8199,41 @@ function registerIpc() {
       data: { title, providerId: launch.providerId, modelId: launch.modelId },
     });
     return { title };
+  });
+
+  handle(IPC.invoke.agentSteer, async (req: AgentSteerRequest) => {
+    if (!host || !sidecar) throw new Error("backend unavailable");
+    if (!req?.sessionId || typeof req.content !== "string" || !req.expectedTurnId ||
+        (!req.content.trim() && !req.attachments?.length)) {
+      throw Object.assign(new Error("Steering input and expectedTurnId required"), { errorCode: ErrorCodes.INVALID_ARGUMENT });
+    }
+    if (activeTurns.get(req.sessionId) !== req.expectedTurnId || turnFinalizations.has(req.sessionId)) {
+      throw Object.assign(new Error("The target turn has ended"), { errorCode: ErrorCodes.TURN_NOT_FOUND });
+    }
+    const context = await sidecar.call<{ projectPath?: string; supportsVision: boolean }>(
+      "agent.steeringContext", { sessionId: req.sessionId, expectedTurnId: req.expectedTurnId },
+    );
+    const prepared = await preparePromptAttachments(
+      dataDir, req.sessionId, context.projectPath, req.attachments ?? [], context.supportsVision,
+    );
+    const session = await host.call<{ session?: { messages?: UiMessage[] } }>("session.get", {
+      id: req.sessionId, messageLimit: 1,
+    });
+    const message: UiMessage = {
+      id: durableUserMessageId(req.messageId, session.session?.messages ?? []),
+      role: "user", content: req.content, status: "complete", createdAt: new Date().toISOString(),
+      ...(prepared.length ? { attachments: prepared.map((attachment) => attachment.message) } : {}),
+    };
+    // Revalidate inside the runtime after all file/host IO. A stale target must
+    // never turn into a normal prompt or alter the next turn's configuration.
+    return sidecar.call<{ accepted: boolean; turnId: string }>("agent.steer", {
+      sessionId: req.sessionId, expectedTurnId: req.expectedTurnId, message,
+      content: appendPromptFallbackPaths(req.content, prepared),
+      attachments: prepared.filter((attachment) => attachment.inlineData).map((attachment) => ({
+        path: attachment.message.ref, name: attachment.message.name, kind: attachment.message.kind,
+        mimeType: attachment.message.mimeType, size: attachment.message.size, data: attachment.inlineData,
+      })),
+    });
   });
 
   handle(IPC.invoke.agentPrompt, async (req: AgentPromptRequest) => {

--- a/apps/desktop/electron/main/index.ts
+++ b/apps/desktop/electron/main/index.ts
@@ -1,3 +1,4 @@
+import { steerActiveTurn, SteeringTranscript } from "./agent-steering";
 import {
   app,
   BrowserWindow,
@@ -983,6 +984,9 @@ const logger = new Logger(
 );
 const persistenceOutbox = new PersistenceOutbox(dataDir, (level, message, data) => {
   logger.app("persistence", level, message, { data });
+});
+const steeringTranscript = new SteeringTranscript(persistenceOutbox, () => host, (message, sessionId, error) => {
+  logger.app("persistence", "warn", message, { sessionId, data: String(error) });
 });
 // The reply currently streaming in each session, checkpointed to host-core so
 // a quit or crash mid-reply keeps the text the user already saw (D299). A
@@ -2375,7 +2379,6 @@ async function importLegacyScheduled() {
 
 /** sessionId → open host turn id, for turn bookkeeping across agent events. */
 const activeTurns = new Map<string, string>();
-const steeringReservedReplies = new Set<string>();
 const sessionOperationTails = new Map<string, Promise<void>>();
 
 async function acquireSessionOperation(sessionId: string): Promise<() => void> {
@@ -4920,7 +4923,7 @@ function wireSidecar(s: AgentSidecar) {
     if (sidecar !== s) return;
     logger.flushChild("agent");
     sidecar = null;
-    steeringReservedReplies.clear();
+    steeringTranscript.clear();
     if (intentional || quitting) return;
     // A sidecar crash closes live approval waiters before the replacement
     // sidecar starts. This prevents an old renderer response from waking a
@@ -5702,25 +5705,7 @@ function persistAgentEvent(envelope: AgentEventEnvelope): UiMessage | undefined 
   if (event.type === "turn_end" && !envelope.parentToolCallId) {
     addActiveTurnUsage(envelope.sessionId, event.subagentUsage);
   }
-  if (event.type === "message_end" && event.message.role === "user" && !envelope.parentToolCallId) {
-    // Reserve the in-flight reply's existing UI position before appending input.
-    // The final assistant snapshot later updates this same transcript row.
-    if (event.precedingAssistant?.role === "assistant") {
-      steeringReservedReplies.add(event.precedingAssistant.id);
-      void persistenceOutbox.enqueue({
-        key: `message:${envelope.sessionId}:${event.precedingAssistant.id}`,
-        sessionId: envelope.sessionId, message: event.precedingAssistant, turnId: envelope.turnId ?? turnId,
-      }, () => host).catch((error) => logger.app("persistence", "warn", "steering checkpoint enqueue failed", {
-        sessionId: envelope.sessionId, data: String(error),
-      }));
-    }
-    void persistenceOutbox.enqueue({
-      key: `message:${envelope.sessionId}:${event.message.id}`,
-      sessionId: envelope.sessionId, message: event.message, turnId: envelope.turnId ?? turnId,
-    }, () => host).catch((error) => logger.app("persistence", "warn", "steering message persistence enqueue failed", {
-      sessionId: envelope.sessionId, data: String(error),
-    }));
-  }
+  steeringTranscript.persistInput(envelope, turnId);
   if (event.type === "message_end" && event.message.role === "assistant") {
     if (!envelope.parentToolCallId && event.message.usage) {
       addActiveTurnUsage(envelope.sessionId, event.message.usage);
@@ -5748,7 +5733,7 @@ function persistAgentEvent(envelope: AgentEventEnvelope): UiMessage | undefined 
     const empty =
       !(event.message.content || "").trim() &&
       !(event.message.thinking || "").trim();
-    const reservedForSteering = steeringReservedReplies.delete(event.message.id);
+    const reservedForSteering = steeringTranscript.settleReply(event.message.id);
     if (failed && empty && !event.message.error && !reservedForSteering) return;
     void persistenceOutbox
       .enqueue(
@@ -8201,40 +8186,11 @@ function registerIpc() {
     return { title };
   });
 
-  handle(IPC.invoke.agentSteer, async (req: AgentSteerRequest) => {
-    if (!host || !sidecar) throw new Error("backend unavailable");
-    if (!req?.sessionId || typeof req.content !== "string" || !req.expectedTurnId ||
-        (!req.content.trim() && !req.attachments?.length)) {
-      throw Object.assign(new Error("Steering input and expectedTurnId required"), { errorCode: ErrorCodes.INVALID_ARGUMENT });
-    }
-    if (activeTurns.get(req.sessionId) !== req.expectedTurnId || turnFinalizations.has(req.sessionId)) {
-      throw Object.assign(new Error("The target turn has ended"), { errorCode: ErrorCodes.TURN_NOT_FOUND });
-    }
-    const context = await sidecar.call<{ projectPath?: string; supportsVision: boolean }>(
-      "agent.steeringContext", { sessionId: req.sessionId, expectedTurnId: req.expectedTurnId },
-    );
-    const prepared = await preparePromptAttachments(
-      dataDir, req.sessionId, context.projectPath, req.attachments ?? [], context.supportsVision,
-    );
-    const session = await host.call<{ session?: { messages?: UiMessage[] } }>("session.get", {
-      id: req.sessionId, messageLimit: 1,
-    });
-    const message: UiMessage = {
-      id: durableUserMessageId(req.messageId, session.session?.messages ?? []),
-      role: "user", content: req.content, status: "complete", createdAt: new Date().toISOString(),
-      ...(prepared.length ? { attachments: prepared.map((attachment) => attachment.message) } : {}),
-    };
-    // Revalidate inside the runtime after all file/host IO. A stale target must
-    // never turn into a normal prompt or alter the next turn's configuration.
-    return sidecar.call<{ accepted: boolean; turnId: string }>("agent.steer", {
-      sessionId: req.sessionId, expectedTurnId: req.expectedTurnId, message,
-      content: appendPromptFallbackPaths(req.content, prepared),
-      attachments: prepared.filter((attachment) => attachment.inlineData).map((attachment) => ({
-        path: attachment.message.ref, name: attachment.message.name, kind: attachment.message.kind,
-        mimeType: attachment.message.mimeType, size: attachment.message.size, data: attachment.inlineData,
-      })),
-    });
-  });
+  handle(IPC.invoke.agentSteer, (req: AgentSteerRequest) => steerActiveTurn(req, {
+    host, sidecar, dataDir,
+    activeTurn: (sessionId) => activeTurns.get(sessionId),
+    isFinalizing: (sessionId) => turnFinalizations.has(sessionId),
+  }));
 
   handle(IPC.invoke.agentPrompt, async (req: AgentPromptRequest) => {
     if (!host || !sidecar) throw new Error("backend unavailable");

--- a/apps/desktop/electron/main/persistence-outbox.ts
+++ b/apps/desktop/electron/main/persistence-outbox.ts
@@ -95,7 +95,9 @@ export class PersistenceOutbox {
         });
         return;
       }
-      this.entries.shift();
+      // An in-flight assistant checkpoint may have been replaced by its final
+      // snapshot while the host append was pending. Keep that newer write.
+      if (this.entries[0] === current) this.entries.shift();
       await this.persist();
     }
   }

--- a/apps/desktop/src/components/Composer.tsx
+++ b/apps/desktop/src/components/Composer.tsx
@@ -628,6 +628,7 @@ export function Composer({
 }) {
   const { t } = useTranslation();
   const sendPrompt = useAppStore((s) => s.sendPrompt);
+  const steerPrompt = useAppStore((s) => s.steerPrompt);
   const removeQueuedPrompt = useAppStore((s) => s.removeQueuedPrompt);
   const sendQueuedNow = useAppStore((s) => s.sendQueuedNow);
   const abort = useAppStore((s) => s.abort);
@@ -1615,7 +1616,7 @@ export function Composer({
     });
   };
 
-  const submit = async () => {
+  const submit = async (steering = false) => {
     // The editable is what the user sees. Under load a state update from a
     // late input event can still be pending when Enter arrives; sending the
     // DOM value rather than the closure's `value` never drops characters.
@@ -1638,7 +1639,7 @@ export function Composer({
     // a session or a model; templates, skills, and unknown /names stay prompt
     // text (main expands templates and routes skills to the Skill tool). Runs
     // before the model-ready gate on purpose.
-    if (serializedContent.startsWith("/")) {
+    if (!steering && serializedContent.startsWith("/")) {
       const commandEnd = serializedContent.search(/\s/);
       const name = serializedContent.slice(
         1,
@@ -1712,7 +1713,7 @@ export function Composer({
         }
       }
     }
-    if (!modelReady) {
+    if (!steering && !modelReady) {
       showToast(t("errors.MODEL_NOT_CONFIGURED"), { variant: "error" });
       return;
     }
@@ -1722,7 +1723,9 @@ export function Composer({
     // puts the draft back.
     const submittedDraft = draftSnapshot(text);
     clearDraftForKey(submittedDraftKey);
-    const accepted = await sendPrompt(inlineContent, submittedDraft);
+    const accepted = steering
+      ? await steerPrompt(inlineContent, submittedDraft)
+      : await sendPrompt(inlineContent, submittedDraft);
     if (!accepted) restoreDraftForKey(submittedDraftKey, submittedDraft);
   };
 
@@ -2467,6 +2470,12 @@ export function Composer({
                   // never drive the autocomplete menu (D125).
                   if (e.nativeEvent.isComposing || e.nativeEvent.keyCode === 229)
                     return;
+                  if (e.key === "Enter" && e.altKey && !e.shiftKey && !e.metaKey && !e.ctrlKey) {
+                    e.preventDefault();
+                    composerAc.close();
+                    void submit(runActive);
+                    return;
+                  }
                   if (composerAc.open && e.key === "Escape") {
                     // Escape closes only the menu; overlay handlers must not
                     // also fire on the same press.
@@ -2963,7 +2972,7 @@ export function Composer({
                   type="button"
                   className="send-btn"
                   ariaLabel={modelReady ? t("chat.send") : t("settings.addProvider")}
-                  tooltip={modelReady ? t("chat.send") : t("settings.addProvider")}
+                  tooltip={runActive ? t("chat.sendWhileRunning") : modelReady ? t("chat.send") : t("settings.addProvider")}
                   disabled={
                     !hasDraftContent ||
                     sendBlocked ||

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   AgentCompactRequest,
   AgentCompactResponse,
   AgentPromptRequest,
+  AgentSteerRequest,
   UiMessage,
   MessageRevisionSummary,
   AgentPromptResponse,
@@ -543,6 +544,8 @@ export const api = {
     prefix: UiMessage[];
   }) =>
     invoke<{ messages: UiMessage[] }>(IPC.invoke.sessionActivateRevision, input),
+  steer: (req: AgentSteerRequest) =>
+    invoke<AgentPromptResponse>(IPC.invoke.agentSteer, req),
   prompt: (req: AgentPromptRequest) =>
     invoke<AgentPromptResponse>(IPC.invoke.agentPrompt, req),
   enhancePrompt: (req: PromptEnhancementRequest) =>

--- a/apps/desktop/src/lib/composer-submission.ts
+++ b/apps/desktop/src/lib/composer-submission.ts
@@ -1,0 +1,94 @@
+import type {
+  AgentPromptAttachment,
+  AgentPromptResponse,
+  AgentSteerRequest,
+  UiMessage,
+} from "@pi-desktop/shared";
+import type { ComposerDraftSnapshot } from "./composer-smart-stop.ts";
+import { optimisticUserMessage } from "./session-transcript.ts";
+
+export function promptAttachmentsFromDraft(
+  references: ComposerDraftSnapshot["fileReferences"],
+): AgentPromptAttachment[] {
+  return references.flatMap((reference) => {
+    const kind =
+      reference.kind ??
+      (/\.(avif|bmp|gif|heic|jpe?g|png|tiff?|webp)$/i.test(reference.path)
+        ? "image"
+        : "file");
+    // Inline chips use tokens for both files and images. Ordinary file chips
+    // already serialize to @path text (the model can Read them); only image
+    // chips need the structured transport for vision/fallback handling.
+    if (reference.token && kind !== "image") return [];
+    return [
+      {
+        path: reference.path,
+        name: reference.name,
+        kind,
+        ...(reference.mimeType ? { mimeType: reference.mimeType } : {}),
+      },
+    ];
+  });
+}
+
+type SteeringTarget = {
+  sessionId?: string | null;
+  turnId?: string;
+  running: boolean;
+  approvalPending: boolean;
+};
+
+type SteeringPorts = {
+  request: (request: AgentSteerRequest) => Promise<AgentPromptResponse>;
+  insert: (sessionId: string, message: UiMessage) => void;
+  retract: (sessionId: string, message: UiMessage) => void;
+  reportError: (error?: unknown) => void;
+};
+
+/** Own admission, optimistic rows and Stop protection for steering submissions. */
+export class SteeringSubmissions {
+  private readonly ids = new Map<string, Set<string>>();
+  private readonly ports: SteeringPorts;
+
+  constructor(ports: SteeringPorts) {
+    this.ports = ports;
+  }
+
+  hasInput(sessionId: string): boolean {
+    return Boolean(this.ids.get(sessionId)?.size);
+  }
+
+  settle(sessionId: string): void {
+    this.ids.delete(sessionId);
+  }
+
+  async submit(
+    content: string,
+    draft: ComposerDraftSnapshot | undefined,
+    target: SteeringTarget,
+  ): Promise<boolean> {
+    const { sessionId, turnId: expectedTurnId } = target;
+    if (!sessionId || !expectedTurnId || !target.running || target.approvalPending) {
+      this.ports.reportError();
+      return false;
+    }
+    const message = optimisticUserMessage(crypto.randomUUID(), content, draft?.fileReferences ?? []);
+    this.ports.insert(sessionId, message);
+    const ids = this.ids.get(sessionId) ?? new Set<string>();
+    ids.add(message.id);
+    this.ids.set(sessionId, ids);
+    try {
+      await this.ports.request({
+        sessionId, expectedTurnId, content, messageId: message.id,
+        attachments: draft ? promptAttachmentsFromDraft(draft.fileReferences) : [],
+      });
+      return true;
+    } catch (error) {
+      this.ports.retract(sessionId, message);
+      ids.delete(message.id);
+      if (!ids.size && this.ids.get(sessionId) === ids) this.ids.delete(sessionId);
+      this.ports.reportError(error);
+      return false;
+    }
+  }
+}

--- a/apps/desktop/src/stores/app-store.ts
+++ b/apps/desktop/src/stores/app-store.ts
@@ -1,3 +1,4 @@
+import { promptAttachmentsFromDraft, SteeringSubmissions } from "../lib/composer-submission";
 import { create } from "zustand";
 import i18n from "i18next";
 import type {
@@ -171,30 +172,6 @@ const ErrorCodes = {
 } as const;
 
 export type { WorkPanelTab } from "../lib/work-panel-tabs";
-
-function promptAttachmentsFromDraft(
-  references: ComposerDraftSnapshot["fileReferences"],
-): AgentPromptAttachment[] {
-  return references.flatMap((reference) => {
-    const kind =
-      reference.kind ??
-      (/\.(avif|bmp|gif|heic|jpe?g|png|tiff?|webp)$/i.test(reference.path)
-        ? "image"
-        : "file");
-    // Inline chips use tokens for both files and images. Ordinary file chips
-    // already serialize to @path text (the model can Read them); only image
-    // chips need the structured transport for vision/fallback handling.
-    if (reference.token && kind !== "image") return [];
-    return [
-      {
-        path: reference.path,
-        name: reference.name,
-        kind,
-        ...(reference.mimeType ? { mimeType: reference.mimeType } : {}),
-      },
-    ];
-  });
-}
 
 function promptAttachmentsFromMessage(
   attachments: UiMessage["attachments"],
@@ -373,7 +350,18 @@ type SubmittedComposerDraft = {
   resolveAbort?: (restored: boolean) => void;
 };
 const submittedComposerDrafts = new Map<string, SubmittedComposerDraft>();
-const steeringMessageIds = new Map<string, Set<string>>();
+const steeringSubmissions = new SteeringSubmissions({
+  request: api.steer,
+  insert: insertOptimisticUserMessage,
+  retract: retractOptimisticUserMessage,
+  reportError: (error) => {
+    const failure = messageErrorFromUnknown(error);
+    useAppStore.getState().showToast(
+      !error || failure.code === "TURN_NOT_FOUND" ? i18n.t("chat.steeringUnavailable") : failure.message,
+      { variant: error ? "error" : "info" },
+    );
+  },
+});
 type SessionConfiguration = Pick<
   SessionSummary,
   "mode" | "providerId" | "modelId" | "thinkingLevel"
@@ -2340,35 +2328,15 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
-  steerPrompt: async (content, draft) => {
+  steerPrompt: (content, draft) => {
     const state = get();
     const sessionId = state.activeSessionId;
-    const expectedTurnId = sessionId ? state.agentStatuses[sessionId]?.currentTurnId : undefined;
-    if (!sessionId || !expectedTurnId || !state.runningSessions[sessionId] || state.pendingPlans[sessionId]?.status === "pending") {
-      state.showToast(i18n.t("chat.steeringUnavailable"), { variant: "info" });
-      return false;
-    }
-    const message = optimisticUserMessage(crypto.randomUUID(), content, draft?.fileReferences ?? []);
-    insertOptimisticUserMessage(sessionId, message);
-    const steeringIds = steeringMessageIds.get(sessionId) ?? new Set<string>();
-    steeringIds.add(message.id);
-    steeringMessageIds.set(sessionId, steeringIds);
-    try {
-      await api.steer({
-        sessionId, expectedTurnId, content, messageId: message.id,
-        attachments: draft ? promptAttachmentsFromDraft(draft.fileReferences) : [],
-      });
-      return true;
-    } catch (error) {
-      retractOptimisticUserMessage(sessionId, message);
-      steeringIds.delete(message.id);
-      if (!steeringIds.size && steeringMessageIds.get(sessionId) === steeringIds) {
-        steeringMessageIds.delete(sessionId);
-      }
-      const failure = messageErrorFromUnknown(error);
-      get().showToast(failure.code === "TURN_NOT_FOUND" ? i18n.t("chat.steeringUnavailable") : failure.message, { variant: "error" });
-      return false;
-    }
+    return steeringSubmissions.submit(content, draft, {
+      sessionId,
+      turnId: sessionId ? state.agentStatuses[sessionId]?.currentTurnId : undefined,
+      running: Boolean(sessionId && state.runningSessions[sessionId]),
+      approvalPending: Boolean(sessionId && state.pendingPlans[sessionId]?.status === "pending"),
+    });
   },
 
   compactContext: async () => {
@@ -2780,7 +2748,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const submittedDraft = submittedComposerDrafts.get(sessionId);
     // A turn containing steering has multiple user inputs. Smart Stop must
     // not remove its last input and restore the original prompt in its place.
-    const preserveSteering = Boolean(steeringMessageIds.get(sessionId)?.size);
+    const preserveSteering = steeringSubmissions.hasInput(sessionId);
     const stoppedAtMs = Date.now();
     if (submittedDraft && !submittedDraft.abortResolution) {
       submittedDraft.abortResolution = new Promise<boolean>((resolve) => {
@@ -3747,7 +3715,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const event = envelope.event;
     if (event.type === "agent_end" || event.type === "error") {
       submittedComposerDrafts.delete(envelope.sessionId);
-      steeringMessageIds.delete(envelope.sessionId);
+      steeringSubmissions.settle(envelope.sessionId);
     }
     if (!flushingStreamUpdates) {
       if (event.type === "message_update") {

--- a/apps/desktop/src/stores/app-store.ts
+++ b/apps/desktop/src/stores/app-store.ts
@@ -373,6 +373,7 @@ type SubmittedComposerDraft = {
   resolveAbort?: (restored: boolean) => void;
 };
 const submittedComposerDrafts = new Map<string, SubmittedComposerDraft>();
+const steeringMessageIds = new Map<string, Set<string>>();
 type SessionConfiguration = Pick<
   SessionSummary,
   "mode" | "providerId" | "modelId" | "thinkingLevel"
@@ -914,6 +915,7 @@ export type AppState = {
     draft?: ComposerDraftSnapshot,
     targetSessionId?: string,
   ) => Promise<boolean>;
+  steerPrompt: (content: string, draft?: ComposerDraftSnapshot) => Promise<boolean>;
   enqueuePrompt: (
     content: string,
     draft?: ComposerDraftSnapshot,
@@ -2338,6 +2340,37 @@ export const useAppStore = create<AppState>((set, get) => ({
     }
   },
 
+  steerPrompt: async (content, draft) => {
+    const state = get();
+    const sessionId = state.activeSessionId;
+    const expectedTurnId = sessionId ? state.agentStatuses[sessionId]?.currentTurnId : undefined;
+    if (!sessionId || !expectedTurnId || !state.runningSessions[sessionId] || state.pendingPlans[sessionId]?.status === "pending") {
+      state.showToast(i18n.t("chat.steeringUnavailable"), { variant: "info" });
+      return false;
+    }
+    const message = optimisticUserMessage(crypto.randomUUID(), content, draft?.fileReferences ?? []);
+    insertOptimisticUserMessage(sessionId, message);
+    const steeringIds = steeringMessageIds.get(sessionId) ?? new Set<string>();
+    steeringIds.add(message.id);
+    steeringMessageIds.set(sessionId, steeringIds);
+    try {
+      await api.steer({
+        sessionId, expectedTurnId, content, messageId: message.id,
+        attachments: draft ? promptAttachmentsFromDraft(draft.fileReferences) : [],
+      });
+      return true;
+    } catch (error) {
+      retractOptimisticUserMessage(sessionId, message);
+      steeringIds.delete(message.id);
+      if (!steeringIds.size && steeringMessageIds.get(sessionId) === steeringIds) {
+        steeringMessageIds.delete(sessionId);
+      }
+      const failure = messageErrorFromUnknown(error);
+      get().showToast(failure.code === "TURN_NOT_FOUND" ? i18n.t("chat.steeringUnavailable") : failure.message, { variant: "error" });
+      return false;
+    }
+  },
+
   compactContext: async () => {
     const state = get();
     const sessionId = state.activeSessionId;
@@ -2745,6 +2778,9 @@ export const useAppStore = create<AppState>((set, get) => ({
     // Capture before awaiting the abort IPC: its terminal event may arrive
     // first and clear the pending snapshot.
     const submittedDraft = submittedComposerDrafts.get(sessionId);
+    // A turn containing steering has multiple user inputs. Smart Stop must
+    // not remove its last input and restore the original prompt in its place.
+    const preserveSteering = Boolean(steeringMessageIds.get(sessionId)?.size);
     const stoppedAtMs = Date.now();
     if (submittedDraft && !submittedDraft.abortResolution) {
       submittedDraft.abortResolution = new Promise<boolean>((resolve) => {
@@ -2782,7 +2818,9 @@ export const useAppStore = create<AppState>((set, get) => ({
       }));
       return;
     }
-    const smartStop = resolveComposerSmartStop(state.messages, submittedDraft);
+    const smartStop = preserveSteering
+      ? { kind: "settle" as const }
+      : resolveComposerSmartStop(state.messages, submittedDraft);
     if (smartStop.kind === "restore") {
       // Nothing came back yet — undo the send: pull the prompt into the
       // composer and drop the turn from the transcript. The rewrite must start
@@ -3709,6 +3747,7 @@ export const useAppStore = create<AppState>((set, get) => ({
     const event = envelope.event;
     if (event.type === "agent_end" || event.type === "error") {
       submittedComposerDrafts.delete(envelope.sessionId);
+      steeringMessageIds.delete(envelope.sessionId);
     }
     if (!flushingStreamUpdates) {
       if (event.type === "message_update") {

--- a/apps/desktop/test/agent-steering.test.mjs
+++ b/apps/desktop/test/agent-steering.test.mjs
@@ -1,0 +1,50 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { steerActiveTurn, SteeringTranscript } from "../electron/main/agent-steering.ts";
+
+function fixture() {
+  const calls = [];
+  let target = "turn-1";
+  const options = {
+    dataDir: "/unused", activeTurn: () => "turn-1", isFinalizing: () => false,
+    host: { call: async (method) => { calls.push(method); return { session: { messages: [] } }; } },
+    sidecar: { call: async (method, params) => {
+      calls.push([method, params]);
+      if (method === "agent.steeringContext") return { supportsVision: true };
+      if (params.expectedTurnId !== target) throw Object.assign(new Error("stale target"), { errorCode: "TURN_NOT_FOUND" });
+      return { accepted: true, turnId: target };
+    } },
+  };
+  return { options, calls, changeTarget: () => { target = "turn-2"; } };
+}
+const request = { sessionId: "session-1", expectedTurnId: "turn-1", content: "redirect" };
+
+test("main routes steering to an existing turn without launching or writing a new turn", async () => {
+  const { options, calls } = fixture();
+  assert.deepEqual(await steerActiveTurn(request, options), { accepted: true, turnId: "turn-1" });
+  assert.deepEqual(calls.map((call) => Array.isArray(call) ? call[0] : call), ["agent.steeringContext", "session.get", "agent.steer"]);
+  assert.equal(calls[2][1].expectedTurnId, "turn-1");
+  assert.equal(calls[2][1].message.role, "user");
+  assert.equal(calls[2][1].provider, undefined);
+});
+
+test("stale targets fail before preparation and are checked again by the runtime after IO", async () => {
+  const first = fixture();
+  await assert.rejects(steerActiveTurn({ ...request, expectedTurnId: "old" }, first.options), { errorCode: "TURN_NOT_FOUND" });
+  assert.deepEqual(first.calls, []);
+  const race = fixture();
+  race.options.host.call = async () => { race.changeTarget(); return { session: { messages: [] } }; };
+  await assert.rejects(steerActiveTurn(request, race.options), { errorCode: "TURN_NOT_FOUND" });
+});
+
+test("steering persistence reserves the preceding reply and retains the explicit turn", () => {
+  const writes = [];
+  const transcript = new SteeringTranscript({ enqueue: async (row) => { writes.push(row); } }, () => null, () => {});
+  const assistant = { id: "reply", role: "assistant", content: "partial", status: "streaming" };
+  const user = { id: "input", role: "user", content: "redirect", status: "complete" };
+  transcript.persistInput({ sessionId: "s1", turnId: "original", ts: 1, event: { type: "message_end", message: user, precedingAssistant: assistant } }, "new-turn");
+  assert.deepEqual(writes.map((row) => [row.message.id, row.turnId]), [["reply", "original"], ["input", "original"]]);
+  assert.equal(transcript.settleReply("reply"), true);
+  assert.equal(transcript.settleReply("reply"), false);
+  transcript.clear();
+});

--- a/apps/desktop/test/composer-send-state.test.mjs
+++ b/apps/desktop/test/composer-send-state.test.mjs
@@ -126,7 +126,7 @@ test("cross-session agent_end cannot clear the active session's running flag", (
 
 test("send clears the composer before the round trip and restores a rejected draft (D287)", () => {
   const submit = composer.match(
-    /const submit = async \(\) => \{[\s\S]*?\n  const applyEditorDraft = \(/,
+    /const submit = async \(steering = false\) => \{[\s\S]*?\n  const applyEditorDraft = \(/,
   )?.[0] ?? "";
   assert.ok(submit.length > 0, "composer submit implementation not found");
   // The DOM value is the source of truth for what gets sent: a state update
@@ -140,10 +140,10 @@ test("send clears the composer before the round trip and restores a rejected dra
   assert.match(submit, /if \(pasting\) showToast\(t\("chat\.pasteInProgress"\)/);
   assert.match(
     submit,
-    /if \(!modelReady\) \{\s*showToast\(t\("errors\.MODEL_NOT_CONFIGURED"\), \{ variant: "error" \}\);\s*return;\s*\}/,
+    /if \(!steering && !modelReady\) \{\s*showToast\(t\("errors\.MODEL_NOT_CONFIGURED"\), \{ variant: "error" \}\);\s*return;\s*\}/,
   );
   // Optimistic clear, restore on rejection. The clear must precede the await.
-  const clearAt = submit.indexOf("clearDraftForKey(submittedDraftKey);\n    const accepted = await sendPrompt(inlineContent, submittedDraft);");
+  const clearAt = submit.indexOf("clearDraftForKey(submittedDraftKey);\n    const accepted = steering");
   assert.ok(clearAt > 0, "draft must be cleared before awaiting sendPrompt");
   assert.match(submit, /if \(!accepted\) restoreDraftForKey\(submittedDraftKey, submittedDraft\);/);
   assert.doesNotMatch(submit, /if \(accepted\) clearDraftForKey\(submittedDraftKey\);\s*\};/);
@@ -161,7 +161,7 @@ test("send clears the composer before the round trip and restores a rejected dra
 
 test("mode slash prefixes send the trailing prompt and retain failed drafts", () => {
   const submit = composer.match(
-    /const submit = async \(\) => \{[\s\S]*?\n  \};\n\n  const composerAc/,
+    /const submit = async \(steering = false\) => \{[\s\S]*?\n  \};\n\n  const composerAc/,
   )?.[0] ?? "";
   assert.ok(submit.length > 0, "composer submit implementation not found");
   assert.match(submit, /const commandBody =/);
@@ -176,7 +176,7 @@ test("mode slash prefixes send the trailing prompt and retain failed drafts", ()
   );
   assert.match(
     submit,
-    /const submittedDraft = draftSnapshot\(text\);\s*clearDraftForKey\(submittedDraftKey\);\s*const accepted = await sendPrompt\(inlineContent, submittedDraft\);\s*if \(!accepted\) restoreDraftForKey\(submittedDraftKey, submittedDraft\);/,
+    /const submittedDraft = draftSnapshot\(text\);\s*clearDraftForKey\(submittedDraftKey\);\s*const accepted = steering[\s\S]*?await steerPrompt\(inlineContent, submittedDraft\)[\s\S]*?await sendPrompt\(inlineContent, submittedDraft\);\s*if \(!accepted\) restoreDraftForKey\(submittedDraftKey, submittedDraft\);/,
   );
   assert.match(store, /draft\?: ComposerDraftSnapshot/);
   const sendPrompt = store.match(

--- a/apps/desktop/test/composer-send-state.test.mjs
+++ b/apps/desktop/test/composer-send-state.test.mjs
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
+import { promptAttachmentsFromDraft } from "../src/lib/composer-submission.ts";
 
 const read = (path) => readFile(new URL(path, import.meta.url), "utf8");
 
@@ -190,17 +191,6 @@ test("mode slash prefixes send the trailing prompt and retain failed drafts", ()
 });
 
 test("draft attachment routing keeps image chips structured and file chips textual", () => {
-  const helperSource = store.match(
-    /function promptAttachmentsFromDraft\([\s\S]*?\n\}\n\nfunction promptAttachmentsFromMessage/,
-  )?.[0]?.replace(/\n\nfunction promptAttachmentsFromMessage[\s\S]*$/, "");
-  assert.ok(helperSource, "prompt attachment mapper not found");
-  const executable = helperSource.replace(
-    /function promptAttachmentsFromDraft\(\s*references: ComposerDraftSnapshot\["fileReferences"\],\s*\): AgentPromptAttachment\[\] \{/,
-    "function promptAttachmentsFromDraft(references) {",
-  );
-  const promptAttachmentsFromDraft = new Function(
-    `${executable}; return promptAttachmentsFromDraft;`,
-  )();
   const attachments = promptAttachmentsFromDraft([
     {
       path: "/tmp/photo.png",

--- a/apps/desktop/test/composer-steering.test.mjs
+++ b/apps/desktop/test/composer-steering.test.mjs
@@ -1,3 +1,4 @@
+import { SteeringSubmissions } from "../src/lib/composer-submission.ts";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
@@ -41,59 +42,55 @@ test("ordinary send, newlines, autocomplete and IME retain their keyboard behavi
   }
 });
 
-const steerBody = store.match(/steerPrompt: (async \(content, draft\) => \{[\s\S]*?\n  \}),\n\n  compactContext:/)?.[1];
-assert.ok(steerBody, "read the actual store steering action");
-function steeringStore(steer = async () => ({ accepted: true, turnId: "turn-1" })) {
-  const state = { activeSessionId: "session-1", runningSessions: { "session-1": true }, agentStatuses: { "session-1": { currentTurnId: "turn-1" } }, pendingPlans: {}, showToast: () => {} };
+function steeringFixture(request = async () => ({ accepted: true, turnId: "turn-1" })) {
   const calls = [];
-  const steeringMessageIds = new Map();
-  const action = new Function("get", "api", "optimisticUserMessage", "insertOptimisticUserMessage", "retractOptimisticUserMessage", "promptAttachmentsFromDraft", "i18n", "crypto", "messageErrorFromUnknown", "steeringMessageIds", `return ${steerBody.replace(/new Set<string>\(\)/g, "new Set()")}`)(
-    () => state, { steer: (request) => { calls.push(request); return steer(request); } },
-    (id, content) => ({ id, content }), (...args) => calls.push(["insert", ...args]), (...args) => calls.push(["retract", ...args]),
-    (references) => references, { t: (key) => key }, { randomUUID: () => "message-1" }, (error) => error, steeringMessageIds,
-  );
-  return { action, state, calls, steeringMessageIds };
+  const service = new SteeringSubmissions({
+    request: (req) => { calls.push(req); return request(req); },
+    insert: (...args) => calls.push(["insert", ...args]),
+    retract: (...args) => calls.push(["retract", ...args]),
+    reportError: () => {},
+  });
+  const target = { sessionId: "session-1", turnId: "turn-1", running: true, approvalPending: false };
+  return { service, target, calls };
 }
 
-test("steering captures the target session and turn, without enqueueing or changing run state", async () => {
-  const { action, state, calls } = steeringStore();
-  assert.equal(await action("direction", { text: "direction", fileReferences: [{ path: "image.png" }] }), true);
-  assert.deepEqual(calls[1], { sessionId: "session-1", expectedTurnId: "turn-1", content: "direction", messageId: "message-1", attachments: [{ path: "image.png" }] });
-  assert.equal(state.runningSessions["session-1"], true);
+test("steering captures the target and transports image chips without changing run state", async () => {
+  const { service, target, calls } = steeringFixture();
+  assert.equal(await service.submit("direction", { text: "direction", fileReferences: [{ path: "image.png", name: "image.png" }] }, target), true);
+  assert.deepEqual(calls[1], { sessionId: "session-1", expectedTurnId: "turn-1", content: "direction", messageId: calls[0][2].id, attachments: [{ path: "image.png", name: "image.png", kind: "image" }] });
+  assert.equal(target.running, true);
+  assert.equal(service.hasInput("session-1"), true);
+  service.settle("session-1");
+  assert.equal(service.hasInput("session-1"), false);
 });
 
-test("a rejected steer retracts only its own optimistic row and lets Composer restore the draft", async () => {
+test("a rejected steer retracts its own row after session navigation and releases Stop protection", async () => {
   let reject;
-  const { action, state, calls } = steeringStore(() => new Promise((_resolve, rejectRequest) => { reject = rejectRequest; }));
-  const pending = action("direction");
-  state.activeSessionId = "session-2";
+  const { service, target, calls } = steeringFixture(() => new Promise((_resolve, rejectRequest) => { reject = rejectRequest; }));
+  const pending = service.submit("direction", undefined, target);
+  assert.equal(service.hasInput("session-1"), true);
+  target.sessionId = "session-2";
   reject({ code: "TURN_NOT_FOUND", message: "target ended" });
   assert.equal(await pending, false);
-  assert.deepEqual(calls.at(-1), ["retract", "session-1", { id: "message-1", content: "direction" }]);
-  assert.equal(state.runningSessions["session-1"], true);
+  assert.deepEqual(calls.at(-1), ["retract", "session-1", calls[0][2]]);
+  assert.equal(service.hasInput("session-1"), false);
   assert.match(composer, /if \(!accepted\) restoreDraftForKey\(submittedDraftKey, submittedDraft\)/);
 });
 
 test("missing turn identity and a pending approval reject before creating a message", async () => {
   for (const reason of ["missing", "approval", "idle"]) {
-    const { action, state, calls } = steeringStore();
-    if (reason === "missing") state.agentStatuses = {};
-    if (reason === "approval") state.pendingPlans["session-1"] = { status: "pending" };
-    if (reason === "idle") state.runningSessions["session-1"] = false;
-    assert.equal(await action("direction"), false);
+    const { service, target, calls } = steeringFixture();
+    if (reason === "missing") target.turnId = undefined;
+    if (reason === "approval") target.approvalPending = true;
+    if (reason === "idle") target.running = false;
+    assert.equal(await service.submit("direction", undefined, target), false);
     assert.deepEqual(calls, []);
   }
 });
 
-
-test("steering protects all turn inputs from smart Stop and a rejected request releases its marker", async () => {
-  const accepted = steeringStore();
-  await accepted.action("direction");
-  assert.equal(accepted.steeringMessageIds.get("session-1").size, 1);
-  const rejected = steeringStore(async () => { throw { code: "TURN_NOT_FOUND" }; });
-  await rejected.action("direction");
-  assert.equal(rejected.steeringMessageIds.size, 0);
-  assert.match(store, /const preserveSteering = Boolean\(steeringMessageIds\.get\(sessionId\)\?\.size\);[\s\S]*?await Promise\.allSettled/);
+test("the store snapshots steering before Stop and clears protection at terminal settlement", () => {
+  assert.match(store, /steerPrompt:[\s\S]*?steeringSubmissions\.submit\(content, draft/);
+  assert.match(store, /const preserveSteering = steeringSubmissions\.hasInput\(sessionId\);[\s\S]*?await Promise\.allSettled/);
   assert.match(store, /const smartStop = preserveSteering\s*\? \{ kind: "settle" as const \}/);
-  assert.match(store, /steeringMessageIds\.delete\(envelope\.sessionId\)/);
+  assert.match(store, /steeringSubmissions\.settle\(envelope\.sessionId\)/);
 });

--- a/apps/desktop/test/composer-steering.test.mjs
+++ b/apps/desktop/test/composer-steering.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const composer = await readFile(new URL("../src/components/Composer.tsx", import.meta.url), "utf8");
+const store = await readFile(new URL("../src/stores/app-store.ts", import.meta.url), "utf8");
+const handler = composer.match(/onKeyDown=\{(\(e\) => \{\s*\/\/ An Enter[\s\S]*?)\}\}\s*\/>/)?.[1] + "}";
+assert.ok(handler.includes("void submit(runActive)"), "read the actual Composer key handler");
+
+function press(overrides = {}, { running = true, enterToSend = true, menu = false } = {}) {
+  const calls = [];
+  const autocomplete = {
+    open: menu, hasItems: menu, highlight: 0, items: ["candidate"],
+    close: () => calls.push("close"), setHighlight: () => {},
+  };
+  const keydown = new Function("composerAc", "acceptCompletion", "submit", "runActive", "enterToSend", `return ${handler}`)(
+    autocomplete, () => calls.push("completion"), (steer = false) => calls.push(steer ? "steer" : "send"), running, enterToSend,
+  );
+  keydown({ key: "Enter", altKey: false, ctrlKey: false, metaKey: false, shiftKey: false,
+    nativeEvent: { isComposing: false, keyCode: 13 }, preventDefault: () => calls.push("prevent"), stopPropagation: () => {}, ...overrides });
+  return calls;
+}
+
+test("Alt+Enter steers a running turn regardless of the Enter preference and autocomplete", () => {
+  for (const enterToSend of [true, false]) for (const menu of [true, false]) {
+    assert.deepEqual(press({ altKey: true }, { enterToSend, menu }), ["prevent", "close", "steer"]);
+  }
+  assert.deepEqual(press({ altKey: true }, { running: false }), ["prevent", "close", "send"]);
+});
+
+test("ordinary send, newlines, autocomplete and IME retain their keyboard behavior", () => {
+  assert.deepEqual(press(), ["prevent", "send"]);
+  assert.deepEqual(press({}, { enterToSend: false }), []);
+  assert.deepEqual(press({ ctrlKey: true }, { enterToSend: false }), ["prevent", "send"]);
+  assert.deepEqual(press({ metaKey: true }, { enterToSend: false }), ["prevent", "send"]);
+  assert.deepEqual(press({ shiftKey: true }), []);
+  assert.deepEqual(press({ altKey: true, shiftKey: true }), []);
+  assert.deepEqual(press({}, { menu: true }), ["prevent", "completion"]);
+  for (const nativeEvent of [{ isComposing: true, keyCode: 13 }, { isComposing: false, keyCode: 229 }]) {
+    assert.deepEqual(press({ altKey: true, nativeEvent }, { menu: true }), []);
+  }
+});
+
+const steerBody = store.match(/steerPrompt: (async \(content, draft\) => \{[\s\S]*?\n  \}),\n\n  compactContext:/)?.[1];
+assert.ok(steerBody, "read the actual store steering action");
+function steeringStore(steer = async () => ({ accepted: true, turnId: "turn-1" })) {
+  const state = { activeSessionId: "session-1", runningSessions: { "session-1": true }, agentStatuses: { "session-1": { currentTurnId: "turn-1" } }, pendingPlans: {}, showToast: () => {} };
+  const calls = [];
+  const steeringMessageIds = new Map();
+  const action = new Function("get", "api", "optimisticUserMessage", "insertOptimisticUserMessage", "retractOptimisticUserMessage", "promptAttachmentsFromDraft", "i18n", "crypto", "messageErrorFromUnknown", "steeringMessageIds", `return ${steerBody.replace(/new Set<string>\(\)/g, "new Set()")}`)(
+    () => state, { steer: (request) => { calls.push(request); return steer(request); } },
+    (id, content) => ({ id, content }), (...args) => calls.push(["insert", ...args]), (...args) => calls.push(["retract", ...args]),
+    (references) => references, { t: (key) => key }, { randomUUID: () => "message-1" }, (error) => error, steeringMessageIds,
+  );
+  return { action, state, calls, steeringMessageIds };
+}
+
+test("steering captures the target session and turn, without enqueueing or changing run state", async () => {
+  const { action, state, calls } = steeringStore();
+  assert.equal(await action("direction", { text: "direction", fileReferences: [{ path: "image.png" }] }), true);
+  assert.deepEqual(calls[1], { sessionId: "session-1", expectedTurnId: "turn-1", content: "direction", messageId: "message-1", attachments: [{ path: "image.png" }] });
+  assert.equal(state.runningSessions["session-1"], true);
+});
+
+test("a rejected steer retracts only its own optimistic row and lets Composer restore the draft", async () => {
+  let reject;
+  const { action, state, calls } = steeringStore(() => new Promise((_resolve, rejectRequest) => { reject = rejectRequest; }));
+  const pending = action("direction");
+  state.activeSessionId = "session-2";
+  reject({ code: "TURN_NOT_FOUND", message: "target ended" });
+  assert.equal(await pending, false);
+  assert.deepEqual(calls.at(-1), ["retract", "session-1", { id: "message-1", content: "direction" }]);
+  assert.equal(state.runningSessions["session-1"], true);
+  assert.match(composer, /if \(!accepted\) restoreDraftForKey\(submittedDraftKey, submittedDraft\)/);
+});
+
+test("missing turn identity and a pending approval reject before creating a message", async () => {
+  for (const reason of ["missing", "approval", "idle"]) {
+    const { action, state, calls } = steeringStore();
+    if (reason === "missing") state.agentStatuses = {};
+    if (reason === "approval") state.pendingPlans["session-1"] = { status: "pending" };
+    if (reason === "idle") state.runningSessions["session-1"] = false;
+    assert.equal(await action("direction"), false);
+    assert.deepEqual(calls, []);
+  }
+});
+
+
+test("steering protects all turn inputs from smart Stop and a rejected request releases its marker", async () => {
+  const accepted = steeringStore();
+  await accepted.action("direction");
+  assert.equal(accepted.steeringMessageIds.get("session-1").size, 1);
+  const rejected = steeringStore(async () => { throw { code: "TURN_NOT_FOUND" }; });
+  await rejected.action("direction");
+  assert.equal(rejected.steeringMessageIds.size, 0);
+  assert.match(store, /const preserveSteering = Boolean\(steeringMessageIds\.get\(sessionId\)\?\.size\);[\s\S]*?await Promise\.allSettled/);
+  assert.match(store, /const smartStop = preserveSteering\s*\? \{ kind: "settle" as const \}/);
+  assert.match(store, /steeringMessageIds\.delete\(envelope\.sessionId\)/);
+});

--- a/apps/desktop/test/persistence-outbox.test.mjs
+++ b/apps/desktop/test/persistence-outbox.test.mjs
@@ -59,3 +59,34 @@ test("deleting a session drops its queued outbox entries (D318)", async () => {
   );
 });
 
+
+
+test("a final reply replaces an in-flight steering checkpoint without being dropped", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-steering-outbox-"));
+  const outbox = new PersistenceOutbox(dir, silent);
+  let releaseFirst;
+  let firstStarted;
+  const started = new Promise((resolve) => { firstStarted = resolve; });
+  const writes = [];
+  const host = {
+    isAvailable: () => true,
+    call: async (_method, params) => {
+      writes.push(params.message);
+      if (writes.length === 1) {
+        firstStarted();
+        await new Promise((resolve) => { releaseFirst = resolve; });
+      }
+    },
+  };
+  const row = { key: "message:session:reply", sessionId: "session", turnId: "turn" };
+  await outbox.enqueue({ ...row, message: { id: "reply", content: "partial", status: "streaming" } }, () => host);
+  await started;
+  await outbox.enqueue({ key: "message:session:input", sessionId: "session", message: { id: "input", content: "steer" }, turnId: "turn" }, () => host);
+  await outbox.enqueue({ ...row, message: { id: "reply", content: "complete reply", status: "complete" } }, () => host);
+  releaseFirst();
+  await outbox.flush(() => host);
+  assert.deepEqual(writes.map((message) => [message.id, message.content]), [
+    ["reply", "partial"], ["reply", "complete reply"], ["input", "steer"],
+  ]);
+  assert.equal(outbox.size(), 0);
+});

--- a/crates/host-core/src/sessions.rs
+++ b/crates/host-core/src/sessions.rs
@@ -1583,12 +1583,43 @@ pub fn append_message(
 ) -> Result<()> {
     let session_created = ensure_session_for_append(db, session_id)?;
     let (record, text) = ui_to_record(message);
-    // Electron may replay an outbox entry after a host restart. Message ids
-    // are globally unique, so an existing row is already the durable result.
+    // A steering input reserves its preceding streaming assistant's position.
+    // Only a terminal assistant snapshot may replace that provisional row;
+    // completed rows remain immutable under outbox replay.
     if message_indexed(db, session_id, &record.id)? {
+        if message.role == "assistant"
+            && message.status.as_deref() != Some("streaming")
+            && streaming_assistant_indexed(db, session_id, &record.id)?
+        {
+            invalidate_transcript_layout(session_id);
+            if !transcripts::update_message(db.data_dir(), session_id, &record)? {
+                return Err(anyhow!("streaming assistant is missing from its transcript"));
+            }
+            db.conn().execute(
+                "UPDATE messages SET text = ?3, is_error = ?4 WHERE session_id = ?1 AND id = ?2",
+                params![session_id, record.id, text, record.is_error],
+            )?;
+        } else {
+            return Ok(());
+        }
+    } else {
+        append_record(db, session_id, &session_created, &record, text.as_deref(), turn_id)?;
+    }
+    if message.role == "assistant" && message.status.as_deref() == Some("streaming") {
+        // Even an empty reservation needs a checkpoint so a crash can settle
+        // it as aborted. Later stream checkpoints replace this snapshot.
+        let existing = transcripts::read_inflight(db.data_dir(), session_id)?;
+        if existing.as_ref().is_none_or(|checkpoint| {
+            ts_to_ms(&checkpoint.message.created_at) < ts_to_ms(&record.created_at)
+        }) {
+            transcripts::write_inflight(db.data_dir(), session_id, &transcripts::InflightRecord {
+                schema: transcripts::INFLIGHT_SCHEMA,
+                session_id: session_id.to_string(), turn_id: turn_id.map(str::to_string),
+                saved_at: ms_to_ts(now_ms()), message: record,
+            })?;
+        }
         return Ok(());
     }
-    append_record(db, session_id, &session_created, &record, text.as_deref(), turn_id)?;
     // The final assistant row supersedes any checkpoint of the same message
     // (D299). A checkpoint for a different id belongs to a newer fragment and
     // stays until its own final row or the turn end settles it.
@@ -1613,6 +1644,25 @@ fn message_indexed(db: &Database, session_id: &str, message_id: &str) -> Result<
         )
         .optional()?;
     Ok(existing.is_some())
+}
+
+/// Find the latest copy by message identity. SQLite sequence numbers are not
+/// physical file offsets when an older transcript contains retried lines.
+fn streaming_assistant_indexed(db: &Database, session_id: &str, message_id: &str) -> Result<bool> {
+    let layout = session_layout(db, session_id)?;
+    let mut end = layout.message_count();
+    while end > 0 {
+        let start = end.saturating_sub(64);
+        let window = transcripts::read_transcript_window_with_layout(
+            db.data_dir(), session_id, &layout, start, Some(end - start),
+        )?;
+        if let Some(record) = window.messages.iter().rev().find(|record| record.id == message_id) {
+            return Ok(record.role == "assistant" && record.meta.as_ref()
+                .and_then(|meta| meta.get("status")).and_then(Value::as_str) == Some("streaming"));
+        }
+        end = start;
+    }
+    Ok(false)
 }
 
 /// Append one canonical record: transcript line first, then the index row.
@@ -1670,7 +1720,9 @@ pub fn save_inflight_message(
     if !has_text {
         return Ok(false);
     }
-    if message_indexed(db, session_id, &message.id)? {
+    if message_indexed(db, session_id, &message.id)?
+        && !streaming_assistant_indexed(db, session_id, &message.id)?
+    {
         transcripts::remove_inflight(db.data_dir(), session_id)?;
         return Ok(false);
     }
@@ -1711,7 +1763,8 @@ pub fn recover_inflight_message(
             return Ok(None);
         }
     };
-    if message_indexed(db, session_id, &inflight.message.id)? {
+    let indexed = message_indexed(db, session_id, &inflight.message.id)?;
+    if indexed && !streaming_assistant_indexed(db, session_id, &inflight.message.id)? {
         transcripts::remove_inflight(db.data_dir(), session_id)?;
         return Ok(None);
     }
@@ -1742,14 +1795,11 @@ pub fn recover_inflight_message(
     meta.insert("status".into(), json!(promoted_status));
     record.meta = Some(Value::Object(meta));
     let text = record_index_text(&record);
-    append_record(
-        db,
-        session_id,
-        &session_created,
-        &record,
-        text.as_deref(),
-        inflight.turn_id.as_deref(),
-    )?;
+    if indexed {
+        append_message(db, session_id, &record_to_ui(record.clone()), inflight.turn_id.as_deref())?;
+    } else {
+        append_record(db, session_id, &session_created, &record, text.as_deref(), inflight.turn_id.as_deref())?;
+    }
     Ok(Some(record_to_ui(record)))
 }
 
@@ -2741,7 +2791,9 @@ pub fn end_turn_settling(
         }
         Some(session_id) if status != "aborted" => {
             if let Some(inflight) = transcripts::read_inflight(db.data_dir(), session_id)? {
-                if message_indexed(db, session_id, &inflight.message.id)? {
+                if message_indexed(db, session_id, &inflight.message.id)?
+                    && !streaming_assistant_indexed(db, session_id, &inflight.message.id)?
+                {
                     transcripts::remove_inflight(db.data_dir(), session_id)?;
                 }
             }
@@ -5067,6 +5119,67 @@ mod tests {
         message.status = Some("streaming".into());
         message.thinking = Some("still thinking".into());
         message
+    }
+
+    #[test]
+    fn steering_reservation_finishes_in_place_and_replay_cannot_overwrite_it() {
+        let db = test_db();
+        let session = create_session(&db, None, None, None, None, None).unwrap();
+        let turn = begin_turn(&db, &session.id, None, None).unwrap();
+        let prefix = user_msg("prefix", "original", "2025-05-01T00:00:00Z");
+        append_message(&db, &session.id, &prefix, Some(&turn)).unwrap();
+        transcripts::append_message(db.data_dir(), &session.id, &session.created_at, &ui_to_record(&prefix).0).unwrap();
+        let partial = streaming_assistant("a1", "partial");
+        append_message(&db, &session.id, &partial, Some(&turn)).unwrap();
+        append_message(&db, &session.id, &user_msg("steer", "new direction", "2025-05-01T00:00:02Z"), Some(&turn)).unwrap();
+        let mut final_row = partial.clone();
+        final_row.content = "complete answer".into();
+        final_row.status = Some("complete".into());
+        append_message(&db, &session.id, &final_row, Some(&turn)).unwrap();
+        append_message(&db, &session.id, &partial, Some(&turn)).unwrap();
+        let mut replay = final_row.clone();
+        replay.content = "stale replay".into();
+        append_message(&db, &session.id, &replay, Some(&turn)).unwrap();
+        let messages = get_session(&db, &session.id).unwrap().unwrap().messages;
+        assert_eq!(messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), vec!["prefix", "a1", "steer"]);
+        assert_eq!(messages[1].content, "complete answer");
+        assert_eq!(messages[1].status.as_deref(), Some("complete"));
+        assert_eq!(search_messages(&db, "complete", 10).unwrap().len(), 1);
+        assert!(transcripts::read_inflight(db.data_dir(), &session.id).unwrap().is_none());
+        let owner: String = db.conn().query_row("SELECT turn_id FROM messages WHERE id = 'a1'", [], |row| row.get(0)).unwrap();
+        assert_eq!(owner, turn);
+    }
+
+    #[test]
+    fn steering_reservation_recovers_the_latest_checkpoint_in_place() {
+        for content in ["", "partial"] {
+            let db = test_db();
+            let session = create_session(&db, None, None, None, None, None).unwrap();
+            let turn = begin_turn(&db, &session.id, None, None).unwrap();
+            append_message(&db, &session.id, &streaming_assistant("a1", content), Some(&turn)).unwrap();
+            append_message(&db, &session.id, &user_msg("steer", "new direction", "2025-05-01T00:00:02Z"), Some(&turn)).unwrap();
+            assert!(save_inflight_message(&db, &session.id, Some(&turn), &streaming_assistant("a1", "latest checkpoint")).unwrap());
+            let recovered = recover_inflight_message(&db, &session.id, false).unwrap().unwrap();
+            assert_eq!(recovered.content, "latest checkpoint");
+            assert_eq!(recovered.status.as_deref(), Some("aborted"));
+            let messages = get_session(&db, &session.id).unwrap().unwrap().messages;
+            assert_eq!(messages.iter().map(|m| m.id.as_str()).collect::<Vec<_>>(), vec!["a1", "steer"]);
+            assert_eq!(messages[0].content, "latest checkpoint");
+        }
+    }
+
+    #[test]
+    fn steering_reservation_does_not_replace_a_newer_checkpoint_and_end_keeps_it() {
+        let db = test_db();
+        let session = create_session(&db, None, None, None, None, None).unwrap();
+        let turn = begin_turn(&db, &session.id, None, None).unwrap();
+        save_inflight_message(&db, &session.id, Some(&turn), &streaming_assistant("a1", "newer text")).unwrap();
+        append_message(&db, &session.id, &streaming_assistant("a1", "older snapshot"), Some(&turn)).unwrap();
+        end_turn(&db, &turn, "completed", None, None, false).unwrap();
+        assert!(transcripts::read_inflight(db.data_dir(), &session.id).unwrap().is_some());
+        let recovered = recover_inflight_message(&db, &session.id, true).unwrap().unwrap();
+        assert_eq!(recovered.content, "newer text");
+        assert_eq!(recovered.status.as_deref(), Some("complete"));
     }
 
     #[test]

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -252,3 +252,4 @@ Each ADR includes:
 | 0232 | Keep macOS DMG opening guidance text-only | Accepted (amends D371 / ADR 0204) |
 | 0233 | Renderer-owned multi-folder project creation | Accepted (amends ADR 0011 / ADR 0016) |
 | 0234 | Keep project memory host-owned and path-scoped | Accepted |
+| active-turn-steering | Bind Composer steering to the active durable turn | Accepted (active-turn-steering; issue #164) |

--- a/docs/adr/active-turn-steering.md
+++ b/docs/adr/active-turn-steering.md
@@ -1,0 +1,67 @@
+# ADR active-turn-steering: Bind Composer steering to the active durable turn
+
+- Status: Accepted
+- Date: 2026-09-12
+- Issue: https://github.com/vastsa/PI-Desktop/issues/164
+
+## Context
+
+The Composer already queues follow-ups through the Host-owned FIFO. Users also
+need to redirect work before the current turn ends. The runtime previously
+exposed prompt, stop and abort only; starting a second prompt while running is
+correctly rejected with `AGENT_BUSY`.
+
+Codex's [app-server turn/steer contract](https://learn.chatgpt.com/docs/app-server#steer-an-active-turn)
+requires an expected active turn id and appends input without opening a new
+turn or changing its configuration. PI-Desktop can provide that admission
+contract using the steering queue already supplied by pi-agent-core.
+
+## Decision
+
+Keep normal Send/Enter as follow-up while running. Use Alt+Enter (Option+Enter
+on macOS) for steering, independent of the Enter-to-send preference. IME
+confirmation and Shift+Enter retain their existing behavior. Idle Alt+Enter
+sends normally. During steering, slash-prefixed drafts remain literal input.
+
+Add a desktop `agent/steer` IPC request with an obligatory `expectedTurnId`.
+Main validates the durable turn and attachments against the running runtime's
+project and model. The existing runtime rechecks admission after asynchronous
+preparation, then queues all accepted messages through native `Agent.steer`.
+Model, workspace, permissions and plan/goal execution identity remain fixed.
+There is no new provider-specific transport, remote RACP method, or new turn.
+
+The current response and started tools finish before input is consumed by the
+next model request. Pending input at pi's closing boundary continues under the
+same durable turn after the current loop releases its busy state. A parent
+waiting for background delegates wakes on steering. Existing recovery owns
+failed-request repair; steering never bypasses it. Stop and terminal errors
+close admission and retain accepted input as history without replaying it.
+
+Main journals accepted user input through the existing persistence outbox. An
+optional `precedingAssistant` snapshot in the user message event reserves an
+in-flight reply's position. Host append idempotency has one bounded exception:
+a terminal assistant can replace its own indexed streaming reservation. It
+retains message order and turn ownership, uses the existing exact-line update,
+and keeps completed messages immutable under retries. In-flight checkpoint
+recovery also updates a reservation in place. This requires no schema change.
+
+## Consequences
+
+- Follow-up and steering have distinct, predictable lifetimes.
+- Stale target rejection restores the Composer draft without failing the run.
+- Attachments, stop behavior and durable transcript ownership use existing
+  boundaries; streaming checkpoints cannot overwrite a completed reply.
+- Completing a reserved reply rewrites one message line through the existing
+  transcript update path. Ordinary turns retain append-only persistence.
+- A steering submission cannot rewrite tokens already being generated or
+  preempt a running tool. Its instruction is available at the next request.
+
+## Validation
+
+Runtime tests exercise a real pi loop with controlled streams/tools, current
+turn identity, images, closing-boundary admission, stop/abort, recovery and an
+idle parent with live delegates. Desktop tests execute the Composer key
+handler and store action, and cover outbox replacement during an in-flight
+write. Host tests verify in-place finalization and crash recovery without
+changing adjacent user rows, turn ownership or replay idempotency. E2E-AGENT-alt-enter-steers-active-turn
+records the full UI scenario; local E2E remains opt-in.

--- a/docs/adr/active-turn-steering.md
+++ b/docs/adr/active-turn-steering.md
@@ -24,9 +24,12 @@ confirmation and Shift+Enter retain their existing behavior. Idle Alt+Enter
 sends normally. During steering, slash-prefixed drafts remain literal input.
 
 Add a desktop `agent/steer` IPC request with an obligatory `expectedTurnId`.
-Main validates the durable turn and attachments against the running runtime's
-project and model. The existing runtime rechecks admission after asynchronous
-preparation, then queues all accepted messages through native `Agent.steer`.
+The main-process steering module validates the durable turn and attachments
+against the running runtime's project and model. A Composer submission module
+owns optimistic rows, rejection rollback and Stop protection; the store wires
+these ports to application state. The existing runtime rechecks admission
+after asynchronous preparation, then queues all accepted messages through
+native `Agent.steer`.
 Model, workspace, permissions and plan/goal execution identity remain fixed.
 There is no new provider-specific transport, remote RACP method, or new turn.
 
@@ -61,7 +64,8 @@ recovery also updates a reservation in place. This requires no schema change.
 Runtime tests exercise a real pi loop with controlled streams/tools, current
 turn identity, images, closing-boundary admission, stop/abort, recovery and an
 idle parent with live delegates. Desktop tests execute the Composer key
-handler and store action, and cover outbox replacement during an in-flight
-write. Host tests verify in-place finalization and crash recovery without
-changing adjacent user rows, turn ownership or replay idempotency. E2E-AGENT-alt-enter-steers-active-turn
-records the full UI scenario; local E2E remains opt-in.
+handler, submission workflow and main-process admission, and cover outbox
+replacement during an in-flight write. Host tests verify in-place finalization
+and crash recovery without changing adjacent user rows, turn ownership or
+replay idempotency. E2E-AGENT-alt-enter-steers-active-turn records the full UI
+scenario; local E2E remains opt-in.

--- a/docs/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/spec/03-runtime/01-ipc-protocol.md
@@ -45,6 +45,7 @@ event: pi-desktop/<domain>/event/<name>
 Examples:
 
 - `pi-desktop/agent/prompt`
+- `pi-desktop/agent/steer`
 - `pi-desktop/agent/stop`
 - `pi-desktop/agent/abort`
 - `pi-desktop/agent/event/message`
@@ -177,6 +178,42 @@ current turn. On a vision runtime, persisted image refs are hydrated from the
 session-bound attachment/scratch roots when history is rebuilt; oversized or
 unavailable images remain path fallbacks. This keeps renderer, main, sidecar, the models.dev catalog, and host
 persistence on one capability-aware contract.
+
+### 5.1a Steer an active turn
+
+`pi-desktop/agent/steer` accepts `AgentSteerRequest`:
+
+```ts
+type AgentSteerRequest = {
+ sessionId: string;
+ expectedTurnId: string;
+ content: string;
+ messageId?: string;
+ attachments?: AgentPromptAttachment[];
+};
+```
+
+It returns `{ accepted: true, turnId }` for the existing turn. Main checks its
+active durable turn, asks the existing sidecar runtime for the active project's
+attachment roots and model image capability, then applies the ordinary bounded
+attachment preparation. The sidecar revalidates `expectedTurnId` after that IO.
+A missing, ended, stopping, or mismatched turn, or a pending plan/goal approval,
+fails with `TURN_NOT_FOUND`; it never falls back to starting or queueing a turn.
+An empty payload fails with `INVALID_ARGUMENT`.
+
+The internal `agent.steeringContext` and `agent.steer` methods use only an
+existing runtime. They do not run launch configuration, `runtimeFor`, or
+`session.beginTurn`. Steering cannot change the active model, permission mode,
+workspace, or approved execution. Slash text is literal input on this channel.
+
+Accepted input is echoed as ordinary user message events with the current
+`turnId` and main-prepared attachment refs. A user `message_end` can additionally
+carry `precedingAssistant`, a streaming snapshot that reserves the reply's
+position before the input is persisted. Main writes both through its replayable
+outbox; the host replaces only that provisional assistant row with its terminal
+snapshot, preserving its id, sequence and owning turn. No image bytes enter the
+durable message. This is an additive desktop channel and event field; it does
+not change RACP, the host RPC version, or the storage schema. See ADR active-turn-steering.
 
 ### 5.2 stop at the next turn boundary
 

--- a/docs/spec/03-runtime/02-agent-runtime.md
+++ b/docs/spec/03-runtime/02-agent-runtime.md
@@ -46,6 +46,7 @@ crates/host-core (tool execution + permissions)
 ```ts
 interface AgentRuntime {
  prompt(input: PromptInput): Promise<{ turnId: string }>
+ steer(input: RuntimePrompt, expectedTurnId: string, message: UiMessage): { accepted: boolean; turnId: string }
  requestGracefulStop(): { requested: boolean }
  abort(turnId?: string): Promise<void>
  getStatus(): RuntimeStatus
@@ -60,6 +61,29 @@ tool batch have completed, and emits a normal `agent_end` before another model
 request. It does not cancel an active provider stream or running tool. An idle
 runtime returns `{ requested: false }`; immediate `abort()` remains the
 separate cancellation path.
+
+### 4.0 Active-turn steering
+
+`steer` validates the current turn identity before changing any state, then
+queues user input through pi-agent-core's native steering queue in `all` mode.
+The current provider request and any started tool batch finish first; all
+accepted input is included at the next model-request boundary within the same
+durable turn. A live provider request is not rewritten or aborted. Main owns
+attachment validation and transcript persistence as for ordinary prompts.
+
+Queued input retains its renderer message id when pi consumes it, including
+when another input arrives before the initial user message has been consumed.
+An admission after pi's last queue poll suppresses the terminal event and
+continues once pi has released the run, with the same turn identity and without
+a second public `agent_start`. Existing context/provider recovery takes
+precedence over that continuation. Steering also wakes a parent that is idle
+waiting for background delegates; it does not cancel those delegates.
+
+Abort, graceful stop, fatal errors and terminal settlement close admission.
+Accepted but unconsumed input remains transcript/context history and is removed
+from pi's steering queue so it cannot execute independently on a later turn.
+An ordinary follow-up stays in the separate Host-owned FIFO until durable turn
+finalization. A steering failure must not terminate the active run.
 
 ### 4.1 Session title summarization
 

--- a/docs/spec/03-runtime/04-data-storage.md
+++ b/docs/spec/03-runtime/04-data-storage.md
@@ -1250,3 +1250,22 @@ columns for anything the host filters, joins, sums, or indexes.
     session, `(pluginId, source, externalId)` idempotency, no project or model
     binding unless an explicit host-created `projectId` is supplied,
     ownership-scoped reads/mutations, and recoverable trash before purge.
+
+
+## Active-turn steering transcript reservations
+
+An accepted steering input is journaled through Electron's existing message
+outbox. If an assistant is still streaming, its provisional snapshot is queued
+first to reserve its transcript position before the new user row. The host
+stores the provisional row and an in-flight checkpoint, including an empty
+reservation so crash recovery can settle it. Further stream checkpoints remain
+valid while the indexed assistant has `status: streaming`.
+
+`session.appendMessage` retains idempotent replay for completed messages. Its
+narrow exception lets a terminal assistant replace an indexed streaming
+assistant with the same session/message id. It updates exactly that transcript
+line and search text, retaining sequence, owning turn and every other row.
+Late partial snapshots and duplicate terminal snapshots cannot overwrite the
+settled result. Recovery promotes the latest checkpoint in that same position.
+The outbox likewise keeps a newer snapshot that replaces an append while its
+host call is still pending. No schema migration is required.

--- a/docs/spec/04-ux/09-interaction-patterns.md
+++ b/docs/spec/04-ux/09-interaction-patterns.md
@@ -31,6 +31,7 @@
 | `Enter` | Send message when Enter-to-send is on; newline when it is off | Composer focused |
 | `Cmd/Ctrl + Enter` | Send message when Enter-to-send is off | Composer focused |
 | `Shift + Enter` | Newline | Composer focused |
+| `Alt + Enter` (`Option + Enter` on macOS) | Steer the current turn; send normally when idle | Composer focused, outside IME composition |
 | `Escape` | Clear input / blur composer | Composer focused |
 | `Cmd/Ctrl + ↑` | Scroll to top of transcript | Transcript focused |
 | `Cmd/Ctrl + ↓` | Scroll to bottom of transcript | Transcript focused |
@@ -644,7 +645,8 @@ may be retained while exactly one workspace supplies the visible shell context.
 ### 3.4 Queued send
 
 - While a session is running, the composer shows Send when the draft has
-  content and Stop when it is empty. Accepted prompts clear the composer and
+  content and Stop when it is empty. Normal Send and Enter-to-send are follow-up
+  actions. Accepted follow-ups clear the composer and
   append to that session's Host-owned, persisted FIFO queue; session switching
   never moves or clears another session's queue.
 - The queue renders above the composer. Each row has an independently
@@ -661,6 +663,29 @@ may be retained while exactly one workspace supplies the visible shell context.
 - Abort remains immediate and never clears the queue. Queued prompts survive
   application restart and remain held until a controller attaches (ADR 0213).
   Finalization during application shutdown must not start another queued turn.
+
+### 3.5 Steer the current turn
+
+- `Alt+Enter` submits the visible draft to the current turn immediately. On
+  macOS this is `Option+Enter`. It works with Enter-to-send on or off and takes
+  precedence over an open autocomplete menu. An idle composer sends normally.
+- `Shift+Enter` and `Alt+Shift+Enter` insert a newline. An Enter confirming an
+  IME candidate (`isComposing` or key code 229) never sends or steers.
+- Steering appears as a user message in the current transcript, clears the
+  draft immediately, and reaches the next model request after the current
+  response/tool batch. It creates no FIFO row and does not interrupt tools.
+- Submission captures the session and current turn identity. If that target
+  ends, rejects input, or is awaiting approval, the draft is restored in its
+  own session and a concise error is shown. New text typed after submission
+  takes precedence over restoration. The running turn is not marked failed.
+- File/image chips use the existing attachment checks and the active model's
+  capability. Queued configuration changes apply to the next ordinary turn;
+  steering keeps the current configuration and sends slash-prefixed text
+  literally, without dispatching local mode or extension commands.
+- Stop retains all accepted steering input as history. Smart Stop does not
+  remove the latest steering row or restore the original prompt over it.
+- The Send tooltip identifies follow-up and the steering shortcut. The
+  existing single Send/Stop slot and Host-owned follow-up list are retained.
 
 ## 3A. Context checkpoint lifecycle
 
@@ -1112,7 +1137,8 @@ Project drag/drop follows these patterns:
 ### 8a.3 Keyboard while open
 
 - ↑/↓ move the highlight with wraparound; Home/End are left to the textarea.
-- Enter / Tab accept the highlighted item; Enter and Cmd/Ctrl+Enter never send
+- Enter / Tab accept the highlighted item; Alt+Enter uses active-turn steering
+  instead of accepting a suggestion. Enter and Cmd/Ctrl+Enter never send
   while the menu has a highlighted item (this precedes the Enter-to-send setting).
   otherwise keeps its behavior).
 - Escape closes only the menu — it takes precedence over the composer's

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -317,3 +317,41 @@ Behavior is identified but the scenario is incomplete or not yet accepted.
 ## Documented
 
 Scenario is fully specified but no automated implementation currently
+
+#### E2E-AGENT-alt-enter-steers-active-turn: Enter follows up and Alt+Enter steers the active turn
+
+- **Preconditions**: A session with a configured model and a controllable
+  streaming response/tool; an image-capable model for the attachment case.
+- **Steps**:
+  1. Start a prompt, then type a follow-up and press Enter. Confirm a FIFO row.
+  2. During the same turn, type a correction and press Alt+Enter. Repeat with
+     an image chip and with two corrections before the current request ends.
+  3. Finish the current response/tool batch and inspect the next model input,
+     transcript and durable turn id. Let the turn finish and observe follow-up.
+  4. Repeat with Enter-to-send off, an open autocomplete menu, Shift+Enter,
+     Alt+Shift+Enter and a Chinese IME candidate confirmation.
+  5. Race steering against turn completion, Stop, and a pending plan approval;
+     switch sessions while a rejected request is pending.
+  6. Change the next-turn model while running, then steer. Verify the active
+     model and permission configuration remain unchanged.
+  7. Steer while the parent waits for background delegates; leave them running
+     and verify the parent receives the correction before their reports finish.
+  8. Reload after completion and simulate a crash after a streaming reply was
+     reserved by steering. Inspect row order, recovered text and owning turn.
+- **Expected**: Enter queues an ordinary follow-up. Alt+Enter creates a user
+  row in the current turn with no queue row or new public `agent_start`.
+  Started tools finish, then the next request contains the corrections/images.
+  The ordinary FIFO starts only after durable turn finalization. IME and
+  newline actions never submit; idle Alt+Enter sends normally. A stale/closed
+  target keeps the draft in its own session and never fails the active turn.
+  Accepted input is not replayed independently after Stop. Completed replies
+  replace provisional snapshots in place; crash recovery preserves the latest
+  checkpoint and adjacent steering rows without duplicates.
+- **Specs linked**: `03-runtime/01-ipc-protocol.md` (§5.1a),
+  `03-runtime/02-agent-runtime.md` (§4.0), `03-runtime/04-data-storage.md`,
+  `04-ux/09-interaction-patterns.md` (§3.5), ADR active-turn-steering, active-turn-steering
+- **Acceptance**: C (conversation & stream), E (tools & permissions), Quality
+- **Milestone**: M5
+- **Status**: Unit-covered (runtime steering, Composer/store keyboard action,
+  outbox and host reservation tests); rendered desktop journey Draft
+  (do not run E2E locally unless explicitly requested)

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -349,9 +349,9 @@ Scenario is fully specified but no automated implementation currently
   checkpoint and adjacent steering rows without duplicates.
 - **Specs linked**: `03-runtime/01-ipc-protocol.md` (§5.1a),
   `03-runtime/02-agent-runtime.md` (§4.0), `03-runtime/04-data-storage.md`,
-  `04-ux/09-interaction-patterns.md` (§3.5), ADR active-turn-steering, active-turn-steering
+  `04-ux/09-interaction-patterns.md` (§3.5), ADR active-turn-steering
 - **Acceptance**: C (conversation & stream), E (tools & permissions), Quality
 - **Milestone**: M5
-- **Status**: Unit-covered (runtime steering, Composer/store keyboard action,
+- **Status**: Unit-covered (runtime steering, Composer keyboard and submission workflows,
   outbox and host reservation tests); rendered desktop journey Draft
   (do not run E2E locally unless explicitly requested)

--- a/docs/spec/08-meta/decisions-log.md
+++ b/docs/spec/08-meta/decisions-log.md
@@ -4696,3 +4696,16 @@ D193, and D194.
   The note provides the narrow Terminal fallback for trusted unsigned builds;
   signed and notarized builds do not need it.
 - Decision D406 amends D371 / ADR 0204. See ADR 0232 and E2E-196b.
+
+
+## 2026-09-12 — Steer the active turn with Alt+Enter
+
+- Normal Send/Enter remains a Host-owned follow-up; Alt+Enter submits input to
+  the current durable turn using a required expected turn id.
+- Reuse pi-agent-core steering at the next model-request boundary, preserve
+  started tools, and retain the active model/workspace/permission configuration.
+- Stop and ended targets reject without redirecting input to another turn.
+  Accepted input remains history without independent replay after cancellation.
+- Journal accepted user input with a provisional preceding reply when needed;
+  finalize only an indexed streaming assistant in place and retain completed
+  message idempotency. See ADR active-turn-steering and E2E-AGENT-alt-enter-steers-active-turn.

--- a/packages/agent-runtime/src/runtime.test.ts
+++ b/packages/agent-runtime/src/runtime.test.ts
@@ -1,3 +1,4 @@
+import { createAssistantMessageEventStream, Type } from "@earendil-works/pi-ai";
 import { describe, expect, it, vi } from "vitest";
 import { estimateTokens } from "@earendil-works/pi-agent-core";
 import { buildSessionContext } from "./session-context.js";
@@ -6292,6 +6293,200 @@ describe("DesktopAgentRuntime deferred tool restore (#225)", () => {
     runtime.setMode("agent");
 
     expect(hasTool(runtime, "BrowserPreview")).toBe(true);
+    await runtime.dispose();
+  });
+});
+
+
+describe("DesktopAgentRuntime active-turn steering", () => {
+  const userText = (message: any) => typeof message.content === "string" ? message.content : message.content[0].text;
+  const steeringMessage = (id: string, content: string): UiMessage => ({
+    id, role: "user", content, status: "complete", createdAt: new Date().toISOString(),
+  });
+
+  function controlledRuntime() {
+    const events: any[] = [];
+    const runtime = createRuntime({ onEvent: (event) => events.push(event) });
+    const agent = (runtime as any).agent;
+    const requests: any[] = [];
+    let finishFirst!: (message?: any) => void;
+    agent.streamFunction = (_model: any, context: any) => {
+      requests.push(structuredClone(context.messages));
+      const stream = createAssistantMessageEventStream();
+      const response = assistantMessage({ content: [{ type: "text", text: "reply" }] }) as any;
+      stream.push({ type: "start", partial: response });
+      const finish = (message = response) => {
+        if (message.stopReason === "aborted" || message.stopReason === "error") {
+          stream.push({ type: "error", reason: message.stopReason, error: message });
+        } else stream.push({ type: "done", reason: message.stopReason, message });
+      };
+      if (requests.length === 1) finishFirst = finish;
+      else finish();
+      return stream;
+    };
+    return { runtime, agent, events, requests, finish: (message?: any) => finishFirst(message) };
+  }
+
+  it("injects text and images into the next request of the same turn", async () => {
+    const { runtime, agent, events, requests, finish } = controlledRuntime();
+    const run = runtime.prompt("original", "original-id", "turn-1");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    expect(runtime.steer({ text: "change direction" }, "turn-1", steeringMessage("steer-1", "change direction")))
+      .toEqual({ accepted: true, turnId: "turn-1" });
+    runtime.steer({ text: "use this", attachments: [{ path: "attachments/image", name: "image.png", kind: "image", mimeType: "image/png", size: 3, data: "YWJj" }] }, "turn-1", steeringMessage("steer-2", "use this"));
+    expect(requests).toHaveLength(1);
+    expect(events.find((event) => event.event.message?.id === "steer-1" && event.event.type === "message_end").event.precedingAssistant.id).toBeTruthy();
+    finish();
+    await run;
+    expect(requests).toHaveLength(2);
+    const users = requests[1].filter((message: any) => message.role === "user");
+    expect(users.map((message: any) => userText(message))).toEqual(["original", "change direction", "use this"]);
+    expect(users[2].content[1]).toEqual({ type: "image", mimeType: "image/png", data: "YWJj" });
+    expect(events.filter((event) => event.event.type === "agent_start")).toHaveLength(1);
+    expect(events.filter((event) => event.event.type === "agent_end")).toHaveLength(1);
+    expect(new Set(events.map((event) => event.turnId))).toEqual(new Set(["turn-1"]));
+    expect((runtime as any).fullEntries.filter((entry: any) => entry.message.role === "user").map((entry: any) => entry.id)).toEqual(["original-id", "steer-1", "steer-2"]);
+    expect(agent.hasQueuedMessages()).toBe(false);
+    await runtime.dispose();
+  });
+
+  it("lets the current tool finish before consuming steering", async () => {
+    const { runtime, agent, requests, finish } = controlledRuntime();
+    let releaseTool!: () => void;
+    let toolStarted = false;
+    vi.spyOn(runtime as any, "resetDeferredToolsForPrompt").mockImplementation(() => {});
+    agent.state.tools = [{ name: "Hold", label: "Hold", description: "Hold", parameters: Type.Object({}), execute: async () => {
+      toolStarted = true;
+      await new Promise<void>((resolve) => { releaseTool = resolve; });
+      return { content: [{ type: "text", text: "tool finished" }] };
+    } }];
+    const run = runtime.prompt("original", "original-id", "turn-tool");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    finish(assistantMessage({ content: [{ type: "toolCall", id: "hold-1", name: "Hold", arguments: {} }], stopReason: "toolUse" }));
+    await vi.waitFor(() => expect(toolStarted).toBe(true));
+    runtime.steer({ text: "new direction" }, "turn-tool", steeringMessage("steer-tool", "new direction"));
+    expect(requests).toHaveLength(1);
+    expect(agent.signal.aborted).toBe(false);
+    releaseTool();
+    await run;
+    expect(requests).toHaveLength(2);
+    expect(requests[1].at(-2).role).toBe("toolResult");
+    expect(userText(requests[1].at(-1))).toBe("new direction");
+    await runtime.dispose();
+  });
+
+  it("drains input admitted after the final queue poll without starting a new durable turn", async () => {
+    const { runtime, events, requests, finish } = controlledRuntime();
+    const handle = (runtime as any).handleAgentEvent.bind(runtime);
+    let admitted = false;
+    (runtime as any).handleAgentEvent = async (event: any) => {
+      if (event.type === "agent_end" && !admitted) {
+        admitted = true;
+        runtime.steer({ text: "last moment" }, "turn-late", steeringMessage("late-id", "last moment"));
+      }
+      await handle(event);
+    };
+    const run = runtime.prompt("original", "original-id", "turn-late");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    finish();
+    await run;
+    expect(requests).toHaveLength(2);
+    expect(userText(requests[1].at(-1))).toBe("last moment");
+    expect(events.filter((event) => event.event.type === "agent_start")).toHaveLength(1);
+    expect(events.filter((event) => event.event.type === "agent_end")).toHaveLength(1);
+    expect(runtime.getStatus().currentTurnId).toBe("turn-late");
+    await runtime.dispose();
+  });
+
+  it.each(["abort", "stop"])("retains accepted input as history after %s without replaying the queue", async (action) => {
+    const { runtime, agent, requests, finish } = controlledRuntime();
+    const run = runtime.prompt("original", "original-id", "turn-stop");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    runtime.steer({ text: "accepted input" }, "turn-stop", steeringMessage("retained-id", "accepted input"));
+    if (action === "abort") await runtime.abort();
+    else runtime.requestGracefulStop();
+    expect(() => runtime.steer({ text: "too late" }, "turn-stop", steeringMessage("rejected", "too late"))).toThrow(/no longer/);
+    finish(assistantMessage({ content: [{ type: "text", text: "stopped" }], stopReason: action === "abort" ? "aborted" : "stop" }));
+    await run;
+    expect(requests).toHaveLength(1);
+    expect(agent.hasQueuedMessages()).toBe(false);
+    expect((runtime as any).fullEntries.some((entry: any) => entry.id === "retained-id")).toBe(true);
+    await runtime.prompt("next prompt", "next-id", "turn-next");
+    expect(requests).toHaveLength(2);
+    expect(requests[1].filter((message: any) => message.role === "user").map((message: any) => userText(message)))
+      .toEqual(["original", "accepted input", "next prompt"]);
+    await runtime.dispose();
+  });
+
+  it("wakes an idle parent immediately while background delegates are still running", async () => {
+    const { runtime, requests, finish } = controlledRuntime();
+    const run = runtime.prompt("original", "original-id", "turn-delegate");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    let resolveCompletion!: () => void;
+    const record = {
+      delegationId: "delegate-1", agentName: "explorer", status: "running",
+      startedEpoch: (runtime as any).turnEpoch, reportDelivered: false,
+      startedAt: Date.now(), lastActivityAt: Date.now(), lastPhase: "waiting-model", turns: 0, toolCalls: 0,
+      completion: new Promise<void>((resolve) => { resolveCompletion = resolve; }),
+      abort: () => {}, result: undefined as any,
+    };
+    (runtime as any).delegations.set(record.delegationId, record);
+    finish();
+    await vi.waitFor(() => expect((runtime as any).steeringWaitAbort).toBeDefined());
+    runtime.steer({ text: "change the parent task" }, "turn-delegate", steeringMessage("parent-steer", "change the parent task"));
+    await vi.waitFor(() => expect(requests).toHaveLength(2));
+    expect(record.status).toBe("running");
+    expect(userText(requests[1].at(-1))).toBe("change the parent task");
+    record.status = "completed";
+    record.result = { report: "delegate report", status: "completed" };
+    resolveCompletion();
+    await run;
+    expect(requests).toHaveLength(3);
+    expect(runtime.getStatus().isRunning).toBe(false);
+    await runtime.dispose();
+  });
+
+  it("leaves pending steering to the existing recovery path", async () => {
+    const { runtime, agent, requests, finish } = controlledRuntime();
+    const run = runtime.prompt("original", "original-id", "turn-recovery");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    const handle = (runtime as any).handleAgentEvent.bind(runtime);
+    let preparedRecovery = false;
+    (runtime as any).handleAgentEvent = async (event: any) => {
+      if (event.type === "agent_end" && !preparedRecovery) {
+        preparedRecovery = true;
+        runtime.steer({ text: "new instruction" }, "turn-recovery", steeringMessage("recovery-steer", "new instruction"));
+        (runtime as any).suppressSilentTurnRunEnd = true;
+      }
+      await handle(event);
+    };
+    const recover = vi.spyOn(runtime as any, "runPendingRecoveries").mockImplementation(async () => {
+      expect(requests).toHaveLength(1);
+      (runtime as any).suppressSilentTurnRunEnd = false;
+      await agent.continue();
+      await agent.waitForIdle();
+      return true;
+    });
+    finish();
+    await run;
+    expect(recover).toHaveBeenCalledOnce();
+    expect(requests).toHaveLength(2);
+    expect(userText(requests[1].at(-1))).toBe("new instruction");
+    await runtime.dispose();
+  });
+
+  it("rejects idle and stale targets without changing the active run", async () => {
+    const { runtime, events, requests, finish } = controlledRuntime();
+    const message = steeringMessage("rejected", "do not accept");
+    expect(() => runtime.steer({ text: message.content }, "missing", message)).toThrow(/no longer/);
+    const run = runtime.prompt("original", "original-id", "current-turn");
+    await vi.waitFor(() => expect(requests).toHaveLength(1));
+    expect(() => runtime.steer({ text: message.content }, "previous-turn", message)).toThrow(/no longer/);
+    expect(runtime.getStatus().currentTurnId).toBe("current-turn");
+    expect(events.some((event) => event.event.message?.id === "rejected")).toBe(false);
+    finish();
+    await run;
+    expect(() => runtime.steer({ text: message.content }, "current-turn", message)).toThrow(/no longer/);
     await runtime.dispose();
   });
 });

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1459,6 +1459,10 @@ export class DesktopAgentRuntime {
   private compactionEnabled: boolean;
   private readonly compactionStrategy: CompactionStrategy;
   private pendingUserMessageId?: string;
+  private acceptingSteering = false;
+  private steeringContinuation = false;
+  private steeringWaitAbort?: AbortController;
+  private pendingSteering = new Map<AgentMessage, string>();
   private pendingOverflow = false;
   private overflowRecoveryAttempted = false;
   private suppressOverflowRunEnd = false;
@@ -1669,6 +1673,7 @@ Delegation rules:
       // `Task` calls — subagent fan-out (ADR 0062) — and every existing tool
       // ordering guarantee is untouched.
       toolExecution: "parallel",
+      steeringMode: "all",
       // A queued renderer prompt asks the current run to finish normally at
       // the next turn boundary. pi-agent-core evaluates this after the
       // assistant response and completed tool batch, before another provider
@@ -3633,6 +3638,8 @@ Delegation rules:
    */
   private terminateParentTurn(): void {
     this.turnHadError = true;
+    this.acceptingSteering = false;
+    this.retainPendingSteering();
     this.abortRunningDelegations();
     this.delegationWaitTargets = undefined;
     this.clearAgentActivity();
@@ -3754,8 +3761,21 @@ Delegation rules:
     ) {
       const targets = this.pendingCurrentTurnDelegations();
       this.beginDelegationWait(targets);
-      await this.waitForDelegations(targets, targets.length, null);
-      this.endDelegationWait();
+      const waitAbort = new AbortController();
+      this.steeringWaitAbort = waitAbort;
+      try {
+        if (!this.pendingSteering.size) {
+          await this.waitForDelegations(targets, targets.length, null, waitAbort.signal);
+        }
+      } finally {
+        if (this.steeringWaitAbort === waitAbort) this.steeringWaitAbort = undefined;
+        this.endDelegationWait();
+      }
+      if (this.pendingSteering.size && !this.runCancelled && !this.turnHadError) {
+        await this.waitForIdleAndSteering();
+        if (!(await this.runPendingRecoveries())) return;
+        continue;
+      }
       if (
         this.disposed ||
         this.runCancelled ||
@@ -3796,7 +3816,7 @@ Delegation rules:
         .join("\n\n");
       this.requestStartedAt = Date.now();
       await this.agent.prompt(text);
-      await this.agent.waitForIdle();
+      await this.waitForIdleAndSteering();
       if (!(await this.runPendingRecoveries())) return;
       if (this.turnHadError || epoch !== this.turnEpoch) {
         if (this.turnHadError) this.terminateParentTurn();
@@ -4610,7 +4630,7 @@ Delegation rules:
       // are suppressed; the retry must close the visible run normally.
       this.suppressProviderRetryRunEnd = false;
       await this.agent.continue();
-      await this.agent.waitForIdle();
+      await this.waitForIdleAndSteering();
     } finally {
       this.providerRetryAbort = undefined;
       this.activeProviderRetryAttempt = 0;
@@ -4647,7 +4667,7 @@ Delegation rules:
     try {
       if (this.disposed) throw new Error("runtime disposed");
       await this.agent.continue();
-      await this.agent.waitForIdle();
+      await this.waitForIdleAndSteering();
     } finally {
       if (this.agent.state.systemPrompt === promptWithNudge) {
         this.agent.state.systemPrompt = promptBefore;
@@ -4716,7 +4736,7 @@ Delegation rules:
         this.turnHadError = false;
         this.requestStartedAt = Date.now();
         await this.agent.continue();
-        await this.agent.waitForIdle();
+        await this.waitForIdleAndSteering();
         continue;
       }
       if (this.pendingSilentTurnRerun) {
@@ -4755,7 +4775,7 @@ Delegation rules:
       if (this.disposed) throw new Error("runtime disposed");
       this.suppressProgressTurnRunEnd = false;
       await this.agent.continue();
-      await this.agent.waitForIdle();
+      await this.waitForIdleAndSteering();
     } finally {
       if (this.agent.state.systemPrompt === promptWithNudge) {
         this.agent.state.systemPrompt = promptBefore;
@@ -5659,6 +5679,7 @@ Delegation rules:
     this.forwardAgentEventToExtensions(event);
     switch (event.type) {
       case "agent_start":
+        if (this.steeringContinuation) break;
         if (
           this.providerRetryInProgress ||
           this.silentTurnRerunInProgress ||
@@ -5765,8 +5786,10 @@ Delegation rules:
       }
       case "message_end": {
         if (event.message.role === "user") {
-          const id = this.pendingUserMessageId ?? randomUUID();
-          this.pendingUserMessageId = undefined;
+          const steeringId = this.pendingSteering.get(event.message);
+          const id = steeringId ?? this.pendingUserMessageId ?? randomUUID();
+          if (steeringId) this.pendingSteering.delete(event.message);
+          else this.pendingUserMessageId = undefined;
           this.appendLiveEntry(id, event.message);
           break;
         }
@@ -6088,6 +6111,9 @@ Delegation rules:
         });
         break;
       case "agent_end":
+        // Input admitted after pi's last queue poll still belongs to this turn.
+        // Continue after the current run settles; never wake the follow-up FIFO.
+        if (this.pendingSteering.size && this.acceptingSteering && !this.runCancelled && !this.turnHadError) break;
         if (
           this.suppressOverflowRunEnd ||
           this.suppressProviderRetryRunEnd ||
@@ -6096,6 +6122,8 @@ Delegation rules:
           this.keepTurnOpenForDelegates()
         )
           break;
+        this.acceptingSteering = false;
+        this.retainPendingSteering();
         this.autonomousExecution = false;
         this.clearAgentActivity();
         this.reportMutationTermination();
@@ -6228,6 +6256,7 @@ Delegation rules:
   ): Promise<{ turnId: string }> {
     if (this.disposed) throw new Error("runtime disposed");
     this.assertNotRunning();
+    this.retainPendingSteering();
     if (execution.sessionId !== this.sessionId) {
       throw Object.assign(new Error("approved plan belongs to another session"), {
         errorCode: "PLAN_EXECUTION_NOT_FOUND",
@@ -6247,6 +6276,7 @@ Delegation rules:
     this.pathInstructionClaims.clear();
     this.hostTurnId = durableTurnId;
     this.turnId = durableTurnId;
+    this.acceptingSteering = true;
     this.pendingUserMessageId = undefined;
     this.gracefulStopRequested = false;
     this.runCancelled = false;
@@ -6297,7 +6327,7 @@ Delegation rules:
     ).messages;
     this.setAgentActivity({ phase: "starting", since: Date.now() });
     await this.agent.continue();
-    await this.agent.waitForIdle();
+    await this.waitForIdleAndSteering();
     // Same recovery contract as a user prompt: a plan execution that overflows,
     // hits a retriable stream failure, or comes back silent must not end as a
     // run with no end events at all.
@@ -6317,9 +6347,11 @@ Delegation rules:
   ): Promise<{ turnId: string }> {
     if (this.disposed) throw new Error("runtime disposed");
     this.assertNotRunning();
+    this.retainPendingSteering();
     const nextTurnId = durableTurnId?.trim() || randomUUID();
     this.hostTurnId = nextTurnId;
     this.turnId = nextTurnId;
+    this.acceptingSteering = true;
     this.gracefulStopRequested = false;
     this.runCancelled = false;
     this.turnSubagentUsage = undefined;
@@ -6373,7 +6405,7 @@ Delegation rules:
       } else {
         await this.agent.prompt(input.text, promptImages(input));
       }
-      await this.agent.waitForIdle();
+      await this.waitForIdleAndSteering();
       void this.extensionRunner?.emit("agent_settled", { type: "agent_settled" });
 
       if (!(await this.runPendingRecoveries())) return { turnId: this.turnId };
@@ -6486,7 +6518,69 @@ Delegation rules:
     });
   }
 
+  /** Resolve attachments against the configuration of the running turn. */
+  steeringContext(expectedTurnId: string): { projectPath?: string; supportsVision: boolean } {
+    if (
+      this.disposed || !this.acceptingSteering || this.runCancelled ||
+      this.turnHadError || !this.getStatus().isRunning ||
+      !expectedTurnId || expectedTurnId !== this.turnId ||
+      this.planningState === "awaiting_approval"
+    ) {
+      throw Object.assign(new Error("The target turn is no longer accepting input"), {
+        errorCode: "TURN_NOT_FOUND",
+      });
+    }
+    return { projectPath: this.projectPath, supportsVision: this.model.input.includes("image") };
+  }
+
+  steer(input: RuntimePrompt, expectedTurnId: string, message: UiMessage): { accepted: boolean; turnId: string } {
+    this.steeringContext(expectedTurnId);
+    const queued: AgentMessage = { role: "user", content: promptContent(input), timestamp: Date.now() };
+    this.pendingSteering.set(queued, message.id);
+    this.agent.steer(queued);
+    this.steeringWaitAbort?.abort();
+    // Main persists this echo through the same outbox as assistant messages.
+    this.emit({ type: "message_start", message });
+    this.emit({
+      type: "message_end", message,
+      ...(this.currentAssistant?.status === "streaming"
+        ? { precedingAssistant: { ...this.currentAssistant } } : {}),
+    });
+    return { accepted: true, turnId: this.turnId! };
+  }
+
+  private retainPendingSteering(): void {
+    this.agent.clearSteeringQueue();
+    for (const [message, id] of this.pendingSteering) {
+      if (!this.agent.state.messages.includes(message)) this.agent.state.messages = [...this.agent.state.messages, message];
+      this.appendLiveEntry(id, message);
+    }
+    this.pendingSteering.clear();
+  }
+
+  private async waitForIdleAndSteering(): Promise<void> {
+    await this.agent.waitForIdle();
+    if (!this.acceptingSteering || this.runCancelled || this.turnHadError) {
+      this.retainPendingSteering();
+      return;
+    }
+    // Recovery owns the next request when the previous response failed. Its
+    // continuation will consume steering after repairing the context/backoff.
+    if (this.suppressOverflowRunEnd || this.suppressProviderRetryRunEnd ||
+        this.suppressSilentTurnRunEnd || this.suppressProgressTurnRunEnd) return;
+    while (this.pendingSteering.size && this.acceptingSteering && !this.runCancelled && !this.turnHadError) {
+      this.steeringContinuation = true;
+      try {
+        await this.agent.continue();
+        await this.agent.waitForIdle();
+      } finally {
+        this.steeringContinuation = false;
+      }
+    }
+  }
+
   async abort(): Promise<void> {
+    this.acceptingSteering = false;
     this.gracefulStopRequested = false;
     this.runCancelled = true;
     this.resolvePendingAskTools();
@@ -6503,6 +6597,7 @@ Delegation rules:
     if (this.disposed || !this.agent.state.isStreaming) {
       return { requested: false };
     }
+    this.acceptingSteering = false;
     this.gracefulStopRequested = true;
     return { requested: true };
   }
@@ -6529,6 +6624,7 @@ Delegation rules:
     this.extensionRunner = undefined;
     if (runner) await runner.dispose().catch(() => undefined);
     this.disposed = true;
+    this.acceptingSteering = false;
     this.runCancelled = true;
     this.resolvePendingAskTools();
     this.abortRunningDelegations();

--- a/packages/agent-runtime/src/sidecar.ts
+++ b/packages/agent-runtime/src/sidecar.ts
@@ -480,6 +480,20 @@ async function handle(method: string, params: any): Promise<unknown> {
       });
       return { accepted: true, turnId };
     }
+    case "agent.steeringContext":
+    case "agent.steer": {
+      const runtime = runtimes.get(String(params.sessionId ?? ""));
+      if (!runtime) {
+        throw Object.assign(new Error("No active turn to steer"), { errorCode: "TURN_NOT_FOUND" });
+      }
+      const expectedTurnId = String(params.expectedTurnId ?? "");
+      if (method === "agent.steeringContext") return runtime.steeringContext(expectedTurnId);
+      return runtime.steer(
+        { text: String(params.content ?? ""), attachments: params.attachments },
+        expectedTurnId,
+        params.message,
+      );
+    }
     case "agent.executeApprovedPlan": {
       const sessionId = String(params.sessionId ?? "");
       const turnId = String(params.turnId ?? "").trim();

--- a/packages/i18n/src/locales/de/index.ts
+++ b/packages/i18n/src/locales/de/index.ts
@@ -240,6 +240,8 @@ export const de = {
     "enhancementFailed": "Eingabeaufforderung zur Verbesserung fehlgeschlagen",
     "dismissEnhancementError": "Verbesserungsfehler verwerfen",
     "abort": "Stoppen",
+    sendWhileRunning: "Folgenachricht senden · Alt+Enter zum Lenken",
+    steeringUnavailable: "Diese Runde nimmt keine weiteren Eingaben an. Dein Entwurf wurde behalten.",
     "stopGenerating": "Generieren stoppen",
     "running": "Funktioniert…",
     "loadingSession": "Konversation wird geladen…",

--- a/packages/i18n/src/locales/en/index.ts
+++ b/packages/i18n/src/locales/en/index.ts
@@ -247,6 +247,8 @@ export const en = {
     enhancementFailed: "Prompt enhancement failed",
     dismissEnhancementError: "Dismiss enhancement error",
     abort: "Stop",
+    sendWhileRunning: "Send follow-up · Alt+Enter to steer",
+    steeringUnavailable: "This turn can no longer accept steering. Your draft was kept.",
     stopGenerating: "Stop generating",
     running: "Working…",
     loadingSession: "Loading conversation…",

--- a/packages/i18n/src/locales/es/index.ts
+++ b/packages/i18n/src/locales/es/index.ts
@@ -240,6 +240,8 @@ export const es = {
     "enhancementFailed": "Error en la mejora de solicitud",
     "dismissEnhancementError": "Descartar error de mejora",
     "abort": "Detener",
+    sendWhileRunning: "Enviar seguimiento · Alt+Enter para orientar",
+    steeringUnavailable: "Este turno ya no acepta indicaciones. Se conservó el borrador.",
     "stopGenerating": "Dejar de generar",
     "running": "Trabajando...",
     "loadingSession": "Cargando conversación...",

--- a/packages/i18n/src/locales/fr/index.ts
+++ b/packages/i18n/src/locales/fr/index.ts
@@ -240,6 +240,8 @@ export const fr = {
     "enhancementFailed": "L'amélioration de l'invite a échoué",
     "dismissEnhancementError": "Ignorer l'erreur d'amélioration",
     "abort": "Arrêter",
+    sendWhileRunning: "Envoyer à la suite · Alt+Entrée pour réorienter",
+    steeringUnavailable: "Ce tour ne peut plus recevoir de consignes. Votre brouillon a été conservé.",
     "stopGenerating": "Arrêter de générer",
     "running": "Travailler…",
     "loadingSession": "Chargement de la conversation…",

--- a/packages/i18n/src/locales/ko/index.ts
+++ b/packages/i18n/src/locales/ko/index.ts
@@ -249,6 +249,8 @@ export const ko = {
     enhancementFailed: "프롬프트 개선 실패",
     dismissEnhancementError: "프롬프트 개선 오류 닫기",
     abort: "중지",
+    sendWhileRunning: "후속 메시지 보내기 · Alt+Enter로 방향 수정",
+    steeringUnavailable: "현재 턴에 지시를 추가할 수 없습니다. 초안은 유지됩니다.",
     stopGenerating: "생성 중지",
     running: "작업 중…",
     loadingSession: "대화 불러오는 중…",

--- a/packages/i18n/src/locales/tr/index.ts
+++ b/packages/i18n/src/locales/tr/index.ts
@@ -249,6 +249,8 @@ export const tr = {
     enhancementFailed: "İstem iyileştirilemedi",
     dismissEnhancementError: "İyileştirme hatasını kapat",
     abort: "Durdur",
+    sendWhileRunning: "Takip mesajı gönder · Alt+Enter ile yönlendir",
+    steeringUnavailable: "Bu tur artık yönlendirme kabul edemiyor. Taslağınız korundu.",
     stopGenerating: "Oluşturmayı durdur",
     running: "Çalışıyor…",
     loadingSession: "Sohbet yükleniyor…",

--- a/packages/i18n/src/locales/zh-CN/index.ts
+++ b/packages/i18n/src/locales/zh-CN/index.ts
@@ -242,6 +242,8 @@ export const zhCN = {
     enhancementFailed: "提示词增强失败",
     dismissEnhancementError: "关闭增强错误",
     abort: "停止",
+    sendWhileRunning: "发送后续消息 · Alt+Enter 立即转向",
+    steeringUnavailable: "当前轮已无法接收转向输入，草稿已保留。",
     stopGenerating: "停止生成",
     running: "正在处理…",
     loadingSession: "正在加载会话…",

--- a/packages/i18n/src/locales/zh-TW/index.ts
+++ b/packages/i18n/src/locales/zh-TW/index.ts
@@ -242,6 +242,8 @@ export const zhTW = {
     enhancementFailed: "提示詞增強失敗",
     dismissEnhancementError: "關閉增強錯誤",
     abort: "停止",
+    sendWhileRunning: "傳送後續訊息 · Alt+Enter 立即轉向",
+    steeringUnavailable: "目前回合已無法接收轉向輸入，草稿已保留。",
     stopGenerating: "停止生成",
     running: "正在處理…",
     loadingSession: "正在載入會話…",

--- a/packages/shared/src/protocol.ts
+++ b/packages/shared/src/protocol.ts
@@ -68,6 +68,7 @@ export const IPC = {
     notificationShowNative: "pi-desktop/notification/showNative",
     notificationSetViewingSession: "pi-desktop/notification/setViewingSession",
     agentPrompt: "pi-desktop/agent/prompt",
+    agentSteer: "pi-desktop/agent/steer",
     promptEnhance: "pi-desktop/prompt/enhance",
     agentCompact: "pi-desktop/agent/compact",
     agentAbort: "pi-desktop/agent/abort",

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -618,6 +618,14 @@ export type AgentPromptAttachment = {
   size?: number;
 };
 
+/** Append input to an existing turn without changing its configuration. */
+export type AgentSteerRequest = Pick<
+  AgentPromptRequest,
+  "sessionId" | "content" | "attachments" | "messageId"
+> & {
+  expectedTurnId: string;
+};
+
 export type AgentPromptResponse = {
   accepted: boolean;
   turnId: string;
@@ -771,7 +779,7 @@ export type AgentEvent =
       deltaText?: string;
       deltaThinking?: string;
     }
-  | { type: "message_end"; message: UiMessage }
+  | { type: "message_end"; message: UiMessage; precedingAssistant?: UiMessage }
   | { type: "tool_start"; toolCallId: string; toolName: string; args: unknown }
   | { type: "tool_update"; toolCallId: string; partialResult?: unknown }
   | {


### PR DESCRIPTION
运行中需要补充或纠正指令时，现有 Composer 只能把输入排队到下一轮。本改动支持 Alt+Enter（macOS 为 Option+Enter）将补充输入交给当前轮，Enter/普通发送继续作为 follow-up 排队。

- 使用 pi-agent-core 原生 `Agent.steer`，绑定 `expectedTurnId`，不创建新轮，也不改变当前模型、工作目录或权限配置。当前回复和已启动的工具完成后，下一次模型请求会收到补充输入。
- 支持图片附件、连续补充、后台子代理等待期间唤醒；保留输入法确认和换行行为，过期请求恢复草稿，Stop 后不自动重放补充输入。
- 保证流式回复与补充消息的持久化顺序，并覆盖崩溃恢复。同步 IPC、运行时、存储、交互规范、ADR 和 `E2E-AGENT-alt-enter-steers-active-turn` 场景。

验证：桌面端 1432 项、运行时 367 项、Rust 会话相关 70 项、国际化 23 项测试通过；TypeScript 类型检查、构建、macOS 打包和 diff 检查通过。本机构建已安装启动，Host 与 Agent Runtime 握手正常。

E2E: NOT RUN
- Suite: `npm run test:e2e`、`npm run test:e2e:plan`、`npm run test:e2e:subagents`，以及新增的 steering 桌面交互场景。
- Reason: 本地 E2E 依仓库规则需显式授权，本次未运行。按照当前 E2E 合并门禁，本 PR 保持草稿。
- Alternative validation: 上述 1892 项测试、类型检查、构建及安装启动验证。
- Remaining risk: 完整桌面交互、真实模型工具链与权限流程仍需受信环境的相关 E2E 验证；当前不应直接合并。

Closes #164
