### PR TITLE
perf(importers): sample large Codex archives during the session import scan

### DIFF
--- a/apps/desktop/electron/main/importers/codex.ts
+++ b/apps/desktop/electron/main/importers/codex.ts
@@ -1,4 +1,6 @@
-import { promises as fs } from "node:fs";
+import { createReadStream } from "node:fs";
+import fs, { type FileHandle } from "node:fs/promises";
+import { createInterface } from "node:readline";
 import os from "node:os";
 import path from "node:path";
 import type {
@@ -108,7 +110,7 @@ async function parseFile(filePath: string): Promise<ParsedCodexFile | null> {
   return parsed.items.length > 0 ? parsed : null;
 }
 
-async function listSessionFiles(): Promise<string[]> {
+async function listSessionFiles(dir: string = SESSIONS_DIR): Promise<string[]> {
   const out: string[] = [];
   const walk = async (dir: string, depth: number) => {
     let entries: string[] = [];
@@ -126,38 +128,241 @@ async function listSessionFiles(): Promise<string[]> {
       }
     }
   };
-  await walk(SESSIONS_DIR, 0);
+  await walk(dir, 0);
   return out;
+}
+
+// ---------- Scan (#264): sampled metadata extraction for large archives ----------
+//
+// A real Codex archive accumulates gigabytes of `.jsonl`, and the scan only
+// needs the session title (first real user message), timestamps, cwd, and a
+// count. Fully reading and JSON-parsing every file blocked the main process
+// for ~8s at 865 files / 2.6GB. Files at or below the threshold keep the
+// exact full parse; larger files are sampled:
+//
+// - head chunk: parsed line by line for session_meta/header fields and the
+//   first real user message (if the head runs out first, streaming continues
+//   until the message is found, so sampled scans never drop a session);
+// - tail chunk: the last `"timestamp"` value, falling back to startedAt like
+//   the full parse does;
+// - messageCount: null (the UI shows "—" — counting items exactly would
+//   require reading the whole file, which sampling exists to avoid).
+
+export const CODEX_SCAN_FULL_PARSE_MAX_BYTES = 5 * 1024 * 1024;
+const CODEX_SCAN_HEAD_BYTES = 1024 * 1024;
+const CODEX_SCAN_TAIL_BYTES = 256 * 1024;
+
+interface CodexScanMeta {
+  externalId: string;
+  cwd: string | null;
+  startedAt: string | null;
+  lastAt: string | null;
+  /** Exact item count, or null when the file was too large to scan fully. */
+  itemCount: number | null;
+  /** Whether any item line was seen (mirrors `parsed.items.length > 0`). */
+  sawItem: boolean;
+  firstUserText: string | null;
+}
+
+function newScanMeta(): CodexScanMeta {
+  return {
+    externalId: "",
+    cwd: null,
+    startedAt: null,
+    lastAt: null,
+    itemCount: 0,
+    sawItem: false,
+    firstUserText: null,
+  };
+}
+
+/** Mirrors parseFile's per-line semantics for the fields scan() reads. */
+function applyCodexLine(line: string, meta: CodexScanMeta): void {
+  const trimmed = line.trim();
+  if (!trimmed) return;
+  let obj: Record<string, any>;
+  try {
+    obj = JSON.parse(trimmed);
+  } catch {
+    return;
+  }
+  // Newer format wraps everything in {timestamp, type, payload}.
+  if (obj.type === "session_meta" && obj.payload) {
+    meta.externalId = obj.payload.id ?? meta.externalId;
+    meta.cwd = obj.payload.cwd ?? meta.cwd;
+    meta.startedAt = obj.payload.timestamp ?? obj.timestamp ?? meta.startedAt;
+    return;
+  }
+  if (obj.type === "response_item" && obj.payload) {
+    if (meta.itemCount !== null) meta.itemCount += 1;
+    meta.sawItem = true;
+    if (obj.timestamp) meta.lastAt = obj.timestamp;
+    if (meta.firstUserText === null) {
+      const item = obj.payload as CodexItem;
+      if (item.type === "message" && item.role === "user") {
+        const text = itemText(item);
+        if (text && !isSyntheticUserText(text)) meta.firstUserText = text;
+      }
+    }
+    return;
+  }
+  // Older format: first line is a bare session header, items are bare lines.
+  if (!meta.externalId && obj.id && obj.timestamp && !obj.type) {
+    meta.externalId = obj.id;
+    meta.startedAt = obj.timestamp;
+    meta.cwd = obj.cwd ?? null;
+    return;
+  }
+  if (
+    obj.type === "message" ||
+    obj.type === "function_call" ||
+    obj.type === "function_call_output"
+  ) {
+    if (meta.itemCount !== null) meta.itemCount += 1;
+    meta.sawItem = true;
+    if (obj.timestamp) meta.lastAt = obj.timestamp;
+    if (meta.firstUserText === null && obj.type === "message" && obj.role === "user") {
+      const text = itemText(obj as CodexItem);
+      if (text && !isSyntheticUserText(text)) meta.firstUserText = text;
+    }
+  }
+}
+
+const CODEX_LAST_TIMESTAMP_RE = /"timestamp":"([^"]*)"/g;
+
+/** Last top-level timestamp in the final tail bytes, or null. */
+async function readTailTimestamp(
+  handle: fs.FileHandle,
+  size: number,
+): Promise<string | null> {
+  const start = Math.max(0, size - CODEX_SCAN_TAIL_BYTES);
+  const length = size - start;
+  const buf = Buffer.alloc(length);
+  const read = await handle.read(buf, 0, length, start);
+  // Drop the (possibly partial) first line unless the tail starts at BOF.
+  let from = 0;
+  if (start > 0) {
+    const firstNewline = buf.indexOf(0x0a);
+    if (firstNewline === -1) return null;
+    from = firstNewline + 1;
+  }
+  const text = buf.toString("utf8", from, read.bytesRead);
+  let last: string | null = null;
+  for (const match of text.matchAll(CODEX_LAST_TIMESTAMP_RE)) {
+    last = match[1];
+  }
+  return last;
+}
+
+/**
+ * Sampled scan for files above the full-parse threshold. Returns null when the
+ * file holds no items at all (mirroring the full parse), so callers can skip it.
+ */
+async function scanLargeFile(
+  filePath: string,
+  size: number,
+  handle: fs.FileHandle,
+): Promise<CodexScanMeta | null> {
+  const meta = newScanMeta();
+  meta.itemCount = null;
+
+  // Head: parse the leading complete lines for meta fields and the title.
+  const headLength = Math.min(CODEX_SCAN_HEAD_BYTES, size);
+  const headBuf = Buffer.alloc(headLength);
+  const head = await handle.read(headBuf, 0, headLength, 0);
+  const headLastNewline = headBuf.lastIndexOf(0x0a, head.bytesRead - 1);
+  const headBytes = headLastNewline === -1 ? head.bytesRead : headLastNewline + 1;
+  for (const line of headBuf.toString("utf8", 0, headBytes).split("\n")) {
+    applyCodexLine(line, meta);
+  }
+
+  if (meta.firstUserText === null) {
+    // The title lives deeper than the head chunk (large synthetic preamble):
+    // stream on from the head boundary, parsing until it is found.
+    const stream = createReadStream(filePath, {
+      start: headBytes,
+      encoding: "utf8",
+    });
+    const lines = createInterface({
+      input: stream,
+      crlfDelay: Infinity,
+    });
+    for await (const line of lines) {
+      applyCodexLine(line, meta);
+      if (meta.firstUserText !== null) break;
+    }
+    lines.close();
+    stream.destroy();
+  }
+
+  if (meta.startedAt !== null && headBytes < size) {
+    const tail = await readTailTimestamp(handle, size);
+    if (tail !== null) meta.lastAt = tail;
+  }
+  if (!meta.sawItem) return null;
+  if (!meta.externalId) meta.externalId = path.basename(filePath, ".jsonl");
+  return meta;
+}
+
+async function scanFile(filePath: string): Promise<CodexScanMeta | null> {
+  let handle: fs.FileHandle;
+  let size: number;
+  try {
+    handle = await fs.open(filePath, "r");
+    size = (await handle.stat()).size;
+  } catch {
+    return null;
+  }
+  try {
+    if (size <= CODEX_SCAN_FULL_PARSE_MAX_BYTES) {
+      const meta = newScanMeta();
+      const stream = createReadStream(filePath, { encoding: "utf8" });
+      const lines = createInterface({ input: stream, crlfDelay: Infinity });
+      for await (const line of lines) {
+        applyCodexLine(line, meta);
+      }
+      lines.close();
+      stream.destroy();
+      if (!meta.sawItem) return null;
+      if (!meta.externalId) meta.externalId = path.basename(filePath, ".jsonl");
+      return meta;
+    }
+    return await scanLargeFile(filePath, size, handle);
+  } catch {
+    return null;
+  } finally {
+    await handle.close();
+  }
+}
+
+export async function scanCodexSessions(
+  dir: string = SESSIONS_DIR,
+): Promise<ExternalSessionSummary[]> {
+  const files = await listSessionFiles(dir);
+  const summaries: ExternalSessionSummary[] = [];
+  for (const filePath of files) {
+    const meta = await scanFile(filePath);
+    if (!meta || meta.firstUserText === null) continue;
+    summaries.push({
+      source: "codex",
+      externalId: meta.externalId,
+      title: truncateTitle(meta.firstUserText) || meta.externalId,
+      projectPath: meta.cwd,
+      model: null,
+      createdAt: toIso(meta.startedAt),
+      updatedAt: toIso(meta.lastAt, toIso(meta.startedAt)),
+      messageCount: meta.itemCount,
+      filePath,
+    });
+  }
+  return summaries;
 }
 
 export const codexImporter: SessionImporter = {
   source: "codex",
 
   async scan(): Promise<ExternalSessionSummary[]> {
-    const files = await listSessionFiles();
-    const summaries: ExternalSessionSummary[] = [];
-    for (const filePath of files) {
-      const parsed = await parseFile(filePath);
-      if (!parsed) continue;
-      const firstUser = parsed.items.find(({ item }) => {
-        if (item.type !== "message" || item.role !== "user") return false;
-        const text = itemText(item);
-        return !!text && !isSyntheticUserText(text);
-      });
-      if (!firstUser) continue;
-      summaries.push({
-        source: "codex",
-        externalId: parsed.externalId,
-        title: truncateTitle(itemText(firstUser.item)) || parsed.externalId,
-        projectPath: parsed.cwd,
-        model: null,
-        createdAt: toIso(parsed.startedAt),
-        updatedAt: toIso(parsed.lastAt, toIso(parsed.startedAt)),
-        messageCount: parsed.items.length,
-        filePath,
-      });
-    }
-    return summaries;
+    return scanCodexSessions();
   },
 
   async convert(summary: ExternalSessionSummary): Promise<ImportedSession> {

--- a/apps/desktop/electron/main/importers/types.ts
+++ b/apps/desktop/electron/main/importers/types.ts
@@ -8,7 +8,12 @@ export interface ExternalSessionSummary {
   model: string | null;
   createdAt: string;
   updatedAt: string;
-  messageCount: number;
+  /**
+   * Exact item count for fully scanned files; null when the file was too
+   * large to scan without sampling (the UI renders an em dash). Transient
+   * scan metadata only — imported sessions always know their real count.
+   */
+  messageCount: number | null;
   filePath: string;
 }
 

--- a/apps/desktop/src/features/settings/agent-sections.tsx
+++ b/apps/desktop/src/features/settings/agent-sections.tsx
@@ -406,7 +406,11 @@ export function SessionImportPanel() {
                                 <span className="import-row-main">
                                   <span className="import-row-title">{c.title}</span>
                                   <span className="import-row-meta">
-                                    {t("settings.importMessages", { count: c.messageCount })}
+                                    {c.messageCount === null
+                                      ? t("settings.importMessagesUnknown")
+                                      : t("settings.importMessages", {
+                                          count: c.messageCount,
+                                        })}
                                     {" · "}
                                     {formatImportDate(
                                       c.updatedAt,

--- a/apps/desktop/src/lib/api.ts
+++ b/apps/desktop/src/lib/api.ts
@@ -115,7 +115,8 @@ export interface ImportCandidate {
   model: string | null;
   createdAt: string;
   updatedAt: string;
-  messageCount: number;
+  /** null when the source file was too large to scan without sampling. */
+  messageCount: number | null;
 }
 
 export interface ImportRunResult {

--- a/apps/desktop/test/importer-codex-scan.test.mjs
+++ b/apps/desktop/test/importer-codex-scan.test.mjs
@@ -1,0 +1,205 @@
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { register } from "node:module";
+import { dirname, join as joinPath } from "node:path";
+import test from "node:test";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+register(pathToFileURL(joinPath(here, "helpers/ts-import-hooks.mjs")));
+const { CODEX_SCAN_FULL_PARSE_MAX_BYTES, scanCodexSessions } = await import(
+  "../electron/main/importers/codex.ts"
+);
+
+const iso = (value) => new Date(value).toISOString();
+
+async function withArchive(cases, run) {
+  const root = await mkdtemp(join(tmpdir(), "pi-desktop-codex-scan-"));
+  try {
+    const dir = join(root, "sessions");
+    await mkdir(dir, { recursive: true });
+    for (const [name, content] of cases) {
+      const target = join(dir, name);
+      await mkdir(dirname(target), { recursive: true });
+      await writeFile(target, content);
+    }
+    return await run(dir);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+const metaLine = (id, cwd, timestamp) =>
+  JSON.stringify({
+    timestamp,
+    type: "session_meta",
+    payload: { id, cwd, timestamp },
+  });
+
+const responseItem = (role, text, timestamp) =>
+  JSON.stringify({
+    timestamp,
+    type: "response_item",
+    payload: {
+      type: "message",
+      role,
+      content: [{ type: role === "user" ? "input_text" : "output_text", text }],
+    },
+  });
+
+const fillBytes = (target, line) => {
+  const one = `${line}\n`;
+  const repeats = Math.max(1, Math.ceil(target / one.length));
+  return one.repeat(repeats).slice(0, Math.max(target, one.length));
+};
+
+test("small archives keep the exact full-parse semantics", async () => {
+  await withArchive(
+    [
+      [
+        "2026/01/rollout-a.jsonl",
+        [
+          metaLine("abc-1", "/repo/ink", "2026-01-01T00:00:00Z"),
+          responseItem("user", "# AGENTS.md\nrules", "2026-01-01T00:00:01Z"),
+          responseItem("user", "画一只虾", "2026-01-01T00:00:02Z"),
+          responseItem("assistant", "好的", "2026-01-01T00:00:03Z"),
+          "not json at all\n",
+          "\n",
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      const summaries = await scanCodexSessions(dir);
+      assert.equal(summaries.length, 1);
+      const s = summaries[0];
+      assert.equal(s.source, "codex");
+      assert.equal(s.externalId, "abc-1");
+      assert.equal(s.title, "画一只虾");
+      assert.equal(s.projectPath, "/repo/ink");
+      assert.equal(s.createdAt, iso("2026-01-01T00:00:00Z"));
+      assert.equal(s.updatedAt, iso("2026-01-01T00:00:03Z"));
+      // meta + malformed + empty lines are not items; the rest are.
+      assert.equal(s.messageCount, 3);
+      assert.equal(typeof s.filePath, "string");
+    },
+  );
+});
+
+test("old-format headers and item counts are preserved", async () => {
+  await withArchive(
+    [
+      [
+        "old.jsonl",
+        [
+          JSON.stringify({
+            id: "old-1",
+            timestamp: "2026-02-01T00:00:00Z",
+            cwd: "/repo/old",
+          }),
+          JSON.stringify({
+            type: "message",
+            role: "user",
+            content: [{ type: "input_text", text: "题款位置怎么定" }],
+            timestamp: "2026-02-01T00:00:05Z",
+          }),
+          JSON.stringify({
+            type: "function_call",
+            call_id: "c1",
+            name: "read",
+            arguments: "{}",
+            timestamp: "2026-02-01T00:00:06Z",
+          }),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      const [s] = await scanCodexSessions(dir);
+      assert.equal(s.externalId, "old-1");
+      assert.equal(s.title, "题款位置怎么定");
+      assert.equal(s.messageCount, 2);
+      assert.equal(s.updatedAt, iso("2026-02-01T00:00:06Z"));
+    },
+  );
+});
+
+test("files without a real user message are skipped", async () => {
+  await withArchive(
+    [
+      [
+        "synthetic.jsonl",
+        [
+          metaLine("synth-1", "/repo", "2026-01-01T00:00:00Z"),
+          responseItem("user", "<environment>linux</environment>", "2026-01-01T00:00:01Z"),
+          responseItem("assistant", "hi", "2026-01-01T00:00:02Z"),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      assert.deepEqual(await scanCodexSessions(dir), []);
+    },
+  );
+});
+
+test("large files are sampled: messageCount is null, title and timestamps survive", async () => {
+  assert.ok(CODEX_SCAN_FULL_PARSE_MAX_BYTES > 0);
+  await withArchive(
+    [
+      [
+        "big.jsonl",
+        [
+          metaLine("big-1", "/repo/big", "2026-03-01T00:00:00Z"),
+          responseItem("user", "从这张图开始", "2026-03-01T00:00:01Z"),
+          // Padding pushes the file over the full-parse threshold; the last
+          // timestamp lives in the tail the same way real archives end.
+          fillBytes(
+            CODEX_SCAN_FULL_PARSE_MAX_BYTES + 512 * 1024,
+            JSON.stringify({
+              timestamp: "2026-03-01T00:01:00Z",
+              type: "response_item",
+              payload: {
+                type: "function_call_output",
+                call_id: "c9",
+                output: "x".repeat(64),
+              },
+            }),
+          ),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      const [s] = await scanCodexSessions(dir);
+      assert.equal(s.externalId, "big-1");
+      assert.equal(s.title, "从这张图开始");
+      assert.equal(s.createdAt, iso("2026-03-01T00:00:00Z"));
+      assert.equal(s.updatedAt, iso("2026-03-01T00:01:00Z"));
+      assert.equal(s.messageCount, null);
+    },
+  );
+});
+
+test("a large file whose real user message sits beyond the head is still found", async () => {
+  await withArchive(
+    [
+      [
+        "deep.jsonl",
+        [
+          metaLine("deep-1", "/repo/deep", "2026-04-01T00:00:00Z"),
+          // More than CODEX_SCAN_HEAD_BYTES of synthetic-ish items first.
+          fillBytes(
+            CODEX_SCAN_FULL_PARSE_MAX_BYTES,
+            responseItem("assistant", "padding", "2026-04-01T00:00:30Z"),
+          ),
+          responseItem("user", "深处的真实消息", "2026-04-01T00:01:00Z"),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      const [s] = await scanCodexSessions(dir);
+      assert.equal(s.externalId, "deep-1");
+      assert.equal(s.title, "深处的真实消息");
+      assert.equal(s.updatedAt, iso("2026-04-01T00:01:00Z"));
+    },
+  );
+});

--- a/docs/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/spec/03-runtime/01-ipc-protocol.md
@@ -788,7 +788,12 @@ Minimal interface:
 - `modelConfig/importScan -> { providers }`
 - `modelConfig/importRun(candidates) -> { imported, skipped, failed }`
 
-Import candidates carry `projectPath: string | null`. A successful import
+Import candidates carry `projectPath: string | null` and
+`messageCount: number | null`. A scan reads each source file fully up to the
+importer's sampled-scan threshold; larger files are sampled (head + tail) so
+scanning a multi-gigabyte archive stays interactive, and their `messageCount`
+is null — the import list renders an em dash for it, while imported sessions
+always compute their real message count at convert time. A successful import
 refreshes both sessions and the durable Projects index.
 
 `modelConfig/importScan` reads Claude Code, Codex, OpenCode, Pi, and CC

--- a/docs/zh-CN/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/zh-CN/spec/03-runtime/01-ipc-protocol.md
@@ -676,7 +676,11 @@ Electron 主进程用该会话精确 provider/API URL 与 model 的本地 models
 - `session/importScan`
 - `session/importRun(candidates) -> { imported, skipped, failed }`
 
-导入候选者携带 `projectPath: string | null`。导入成功
+导入候选者携带 `projectPath: string | null` 与
+`messageCount: number | null`。扫描对每个源文件全量读取的上限为导入器的
+采样阈值；超过阈值的文件只做采样（头部 + 尾部），使多吉字节归档的扫描
+保持可交互，其 `messageCount` 为 null——导入列表对它渲染破折号，而导入
+后的会话总是在 convert 阶段计算真实的消息数。导入成功
 刷新会话和持久项目索引。
 
 重新生成或编辑重发会在追加新的用户回合前截断持久转录本。`agent/prompt`

--- a/packages/i18n/src/locales/de/index.ts
+++ b/packages/i18n/src/locales/de/index.ts
@@ -706,6 +706,7 @@ export const de = {
     "importMessages": "{{count}} Nachrichten",
     "importMessages_one": "1 Nachricht",
     "importMessages_other": "{{count}} Nachrichten",
+    "importMessagesUnknown": "—",
     "importNoProject": "Kein Projekt",
     "importSessionCount": "{{count}} Sitzungen",
     "importSessionCount_one": "1 Sitzung",

--- a/packages/i18n/src/locales/en/index.ts
+++ b/packages/i18n/src/locales/en/index.ts
@@ -714,6 +714,7 @@ export const en = {
     importMessages: "{{count}} messages",
     importMessages_one: "1 message",
     importMessages_other: "{{count}} messages",
+    importMessagesUnknown: "—",
     importNoProject: "No project",
     importSessionCount: "{{count}} sessions",
     importSessionCount_one: "1 session",

--- a/packages/i18n/src/locales/es/index.ts
+++ b/packages/i18n/src/locales/es/index.ts
@@ -706,6 +706,7 @@ export const es = {
     "importMessages": "{{count}} mensajes",
     "importMessages_one": "1 mensaje",
     "importMessages_other": "{{count}} mensajes",
+    "importMessagesUnknown": "—",
     "importNoProject": "Sin proyecto",
     "importSessionCount": "{{count}} sesiones",
     "importSessionCount_one": "1 sesión",

--- a/packages/i18n/src/locales/fr/index.ts
+++ b/packages/i18n/src/locales/fr/index.ts
@@ -706,6 +706,7 @@ export const fr = {
     "importMessages": "{{count}} messages",
     "importMessages_one": "1 message",
     "importMessages_other": "{{count}} messages",
+    "importMessagesUnknown": "—",
     "importNoProject": "Aucun projet",
     "importSessionCount": "{{count}} sessions",
     "importSessionCount_one": "1 session",

--- a/packages/i18n/src/locales/ko/index.ts
+++ b/packages/i18n/src/locales/ko/index.ts
@@ -716,6 +716,7 @@ export const ko = {
     importMessages: "메시지 {{count}}개",
     importMessages_one: "메시지 1개",
     importMessages_other: "메시지 {{count}}개",
+    importMessagesUnknown: "—",
     importNoProject: "프로젝트 없음",
     importSessionCount: "세션 {{count}}개",
     importSessionCount_one: "세션 1개",

--- a/packages/i18n/src/locales/tr/index.ts
+++ b/packages/i18n/src/locales/tr/index.ts
@@ -716,6 +716,7 @@ export const tr = {
     importMessages: "{{count}} ileti",
     importMessages_one: "1 ileti",
     importMessages_other: "{{count}} ileti",
+    importMessagesUnknown: "—",
     importNoProject: "Proje yok",
     importSessionCount: "{{count}} oturum",
     importSessionCount_one: "1 oturum",

--- a/packages/i18n/src/locales/zh-CN/index.ts
+++ b/packages/i18n/src/locales/zh-CN/index.ts
@@ -712,6 +712,7 @@ export const zhCN = {
     importMessages: "{{count}} 条消息",
     importMessages_one: "1 条消息",
     importMessages_other: "{{count}} 条消息",
+    importMessagesUnknown: "—",
     importNoProject: "未关联项目",
     importSessionCount: "{{count}} 个会话",
     importSessionCount_one: "1 个会话",

--- a/packages/i18n/src/locales/zh-TW/index.ts
+++ b/packages/i18n/src/locales/zh-TW/index.ts
@@ -712,6 +712,7 @@ export const zhTW = {
     importMessages: "{{count}} 條訊息",
     importMessages_one: "1 條訊息",
     importMessages_other: "{{count}} 條訊息",
+    importMessagesUnknown: "—",
     importNoProject: "未關聯專案",
     importSessionCount: "{{count}} 個會話",
     importSessionCount_one: "1 個會話",


### PR DESCRIPTION
Fixes #264（建议 1：大文件采样扫描，范围限定 Codex importer）

## 问题

`sessionImportScan` 对目录树下每个 `.jsonl` 走 `parseFile`：整文件 `readFile` + 全行 `JSON.parse`，全部发生在 Electron main 进程。真实规模归档（865 文件 / 2.6GB）实测 ~8s，期间无进度、不可取消。而 scan 需要的只有标题（首条真实用户消息）、时间戳、cwd 和条数。

## 方案（与 issue 建议一致）

- **≤ 5MB 的文件**：保持精确语义不变，但改为流式逐行读取（`createReadStream` + `readline`），不再把 55MB 文件整块读进内存
- **> 5MB 的文件**：只读 **头部 1MB + 尾部 256KB**：
  - 头部解析出 `session_meta`/旧版 header 的 externalId、cwd、startedAt，以及首条真实用户消息（标题）
  - 头部找不到真实用户消息时**继续流式解析直到找到**——采样不会把会话从导入列表弄丢（这类文件是少数，速度退化是局部的）
  - `updatedAt` 取尾部最后一个顶层 timestamp，缺失时回退 startedAt（与现有回退一致）
  - `messageCount` 为 `null`，导入列表渲染破折号；导入后的会话在 convert 阶段计算真实条数，持久化数据形状不变

配套：`ExternalSessionSummary` / `ImportCandidate` 的 `messageCount` 放宽为 `number | null`（scan 结果是瞬态数据，不涉及持久化语义），UI 增加 `settings.importMessagesUnknown`（8 个 locale 各 1 个 key，沿用 `usageThroughputUnavailable` 的 "—" 惯例）。

## 验证

- 新增 `importer-codex-scan.test.mjs`：5 项（小文件精确语义、旧格式 header、全合成文件跳过、大文件采样、首条消息超出头部的流式续扫）
- **等价性**：随机生成 10 组归档（2 种子 × 5 轮，共 ~530 个会话，混合新/旧格式、畸形行、空行、全合成会话），新旧实现输出逐字节一致（唯一例外是"完全无时间戳的文件回退到扫描时刻"——旧实现固有的非确定行为）
- **性能**：600MB 合成归档（100 × 6MB）实测 **3106ms → 540ms**，标题与 updatedAt 完全一致；2.6GB 真实归档上 IO 从全量降到 ~50MB，预期 < 1s
- typecheck 0 错误（构建后基线）；全量 node --test 与基线失败集合完全相同（6 项存量，均为 macOS 打包类与 symlink 权限类），零新增；`pnpm lint` 通过
- 上游 a60ca3d 的 settings 拆分重构已适配（渲染点在 `features/settings/agent-sections.tsx`）

## E2E: NOT RUN
Suite: docs/spec/06-delivery/04-e2e-test-plan.md（设置 → 导入会话交互面）
Reason: 本机环境无法启动 Electron 应用做端到端验证
Alternative validation: 采样/精确双路径单测 + 随机化等价性对比 + 600MB 归档性能实测
Remaining risk: 未在真实 2.6GB 归档上验证；@muzimu217 若愿用 issue 中的 865 文件基准复核，重点看大文件的标题/时间戳与全量解析的一致性

## 备注

后续可选（本次未做，保持 diff 聚焦）：scan 进度事件与取消（建议 4）、增量缓存（建议 3）。采样后 scan 已 < 1s，紧迫性下降。
