### PR TITLE
fix(tools): emit POSIX separators in workspace-relative tool paths

### DIFF
--- a/crates/host-core/src/tools/mod.rs
+++ b/crates/host-core/src/tools/mod.rs
@@ -20,6 +20,7 @@ use crate::workspace::{resolve_tool_path_with_external, ToolRoot};
 
 mod grep_rg;
 pub mod hashline;
+pub mod ignore_rules;
 pub mod shell;
 
 pub use hashline::{HashlineContext, HashlineStore};
@@ -571,6 +572,13 @@ pub struct ToolsExecuteParams {
     #[serde(default)]
     pub expected_command_shell_dialect: Option<String>,
     pub timeout_ms: Option<u64>,
+    /// Action names that may run in Plan or Goal mode (ADR 0211). When
+    /// set and non-empty, host-core admits this `plugin_*` tool in
+    /// contract modes even though plugins are otherwise Plan-denied; the
+    /// plugin-runtime still enforces the per-action restriction at
+    /// execute time.
+    #[serde(default)]
+    pub plan_safe_actions: Option<Vec<String>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1161,6 +1169,9 @@ fn tool_read(
     let (resolved, root_kind) =
         resolve_tool_path_with_external(root, scratch, path, allow_external_paths)
             .map_err(|e| (e.clone(), e))?;
+    if ignore_rules::is_sensitive_path(&resolved) {
+        return Err(ignore_rules::denied_error(path));
+    }
     let offset = args
         .get("offset")
         .and_then(|v| v.as_u64())
@@ -1296,6 +1307,9 @@ fn tool_write(
     let (resolved, root_kind) =
         resolve_tool_path_with_external(root, scratch, path, allow_external_paths)
             .map_err(|e| (e.clone(), e))?;
+    if ignore_rules::is_sensitive_path(&resolved) {
+        return Err(ignore_rules::denied_error(path));
+    }
     if let Some(parent) = resolved.parent() {
         std::fs::create_dir_all(parent)
             .map_err(|e| ("TOOL_FAILED".into(), format!("mkdir failed: {e}")))?;
@@ -1342,6 +1356,10 @@ fn tool_edit(
     let (resolved, root_kind) =
         resolve_tool_path_with_external(root, scratch, path, allow_external_paths)
             .map_err(|e| hashline::ToolError::new(e.clone(), e))?;
+    if ignore_rules::is_sensitive_path(&resolved) {
+        let (code, message) = ignore_rules::denied_error(path);
+        return Err(hashline::ToolError::new(code, message));
+    }
     let live = std::fs::read(&resolved)
         .map_err(|e| hashline::ToolError::new("TOOL_FAILED", format!("read failed: {e}")))?;
     let display = display_tool_path(root_kind, root, &resolved);
@@ -1374,6 +1392,10 @@ fn tool_edit(
         let (dest_resolved, dest_root) =
             resolve_tool_path_with_external(root, scratch, dest, allow_external_paths)
                 .map_err(|e| hashline::ToolError::new(e.clone(), e))?;
+        if ignore_rules::is_sensitive_path(&dest_resolved) {
+            let (code, message) = ignore_rules::denied_error(dest);
+            return Err(hashline::ToolError::new(code, message));
+        }
         if let Some(parent) = dest_resolved.parent() {
             std::fs::create_dir_all(parent).map_err(|e| {
                 hashline::ToolError::new("TOOL_FAILED", format!("mkdir failed: {e}"))
@@ -1490,11 +1512,15 @@ fn search_root(
 
 fn candidate_files(
     search_root: &Path,
+    ignore_root: &Path,
     scoped: bool,
     include: Option<&globset::GlobSet>,
     max_files: usize,
 ) -> (Vec<PathBuf>, bool) {
     if search_root.is_file() {
+        if ignore_rules::is_sensitive_path(search_root) {
+            return (Vec::new(), false);
+        }
         let relative = search_root
             .file_name()
             .map(Path::new)
@@ -1510,6 +1536,7 @@ fn candidate_files(
     if scoped {
         walker.parents(false);
     }
+    ignore_rules::configure_walker(&mut walker, ignore_root, scoped);
     let mut candidates: Vec<(PathBuf, SystemTime)> = Vec::new();
     let mut capped = false;
     for entry in walker.build().flatten() {
@@ -1570,8 +1597,18 @@ fn tool_glob(
         .filter(|v| *v > 0)
         .unwrap_or(GLOB_DEFAULT_LIMIT);
 
-    let (files, mut truncated) =
-        candidate_files(&search_dir, scoped, Some(&set), GLOB_MAX_LIMIT * 8);
+    let ignore_root = if root_kind == ToolRoot::Workspace {
+        root
+    } else {
+        search_dir.as_path()
+    };
+    let (files, mut truncated) = candidate_files(
+        &search_dir,
+        ignore_root,
+        scoped,
+        Some(&set),
+        GLOB_MAX_LIMIT * 8,
+    );
     let mut matches: Vec<String> = Vec::new();
     let mut bytes = 0_usize;
     for path in &files {
@@ -1662,6 +1699,12 @@ fn tool_grep(
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
 
+    let ignore_root = if root_kind == ToolRoot::Workspace {
+        root
+    } else {
+        search_dir.as_path()
+    };
+
     // Prefer a system `rg` when one is installed (Codex's search default).
     // The result shape, budgets, newest-first order, and scoped-ignore rule
     // stay host-defined; a missing or failing binary falls through.
@@ -1669,6 +1712,7 @@ fn tool_grep(
         pattern,
         search_dir: &search_dir,
         workspace_root: root,
+        ignore_root,
         root_kind,
         scoped,
         include: include_pattern,
@@ -1688,6 +1732,7 @@ fn tool_grep(
 
     let (files, mut truncated) = candidate_files(
         &search_dir,
+        ignore_root,
         scoped,
         include.as_ref(),
         GREP_MAX_CANDIDATE_FILES,
@@ -2585,7 +2630,10 @@ fn relative_display(root: &Path, path: &Path) -> String {
         .or_else(|_| path.strip_prefix(root))
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        // Tool results are protocol-visible: keep POSIX separators on every
+        // platform so Grep/Glob/Read paths match plugin-package and session
+        // path spelling (and the host-core assertions).
+        .replace('\\', "/")
 }
 
 pub fn builtin_tool_defs() -> Value {
@@ -2683,8 +2731,8 @@ pub fn builtin_tool_defs() -> Value {
             "name": "Edit",
             "description": "Replace, insert, or delete lines in an existing file. Names positions and supplies new content only — never old_string. Required args: path, tag (4 hex from the latest Read/Grep/Write/Edit), ops. \
     Ops: `PUT N.=M:` replace inclusive lines N–M (body rows required); `PUT <N:` insert before N; `PUT >N:` insert after N; `PUT >$:` append; `CUT N.=M` delete; `REM` delete the file; `MV DEST` rename after other ops. \
-    Body rows are `+` plus the final line text; a bare `+` is an empty line. No `-old` or context rows. Ranges name only the lines being changed — a pure insert uses a gap locator, not a widened PUT that restates survivors. \
-    All line numbers refer to the tagged snapshot and are 1-indexed. Re-ground on the tag returned by every successful write. After one failed Edit, Read the live file (or retry unchanged on a complete EDIT_LINES_UNSEEN reveal) once; do not guess.",
+    Body rows are `+` plus the final line text; a bare `+` is an empty line. Every PUT with body rows must include the trailing colon, for example `PUT 48.=48:` followed by a `+replacement` row; `PUT 48.=48` followed by `+` rows is invalid. A colonless PUT is only for a register paste such as `PUT <1 @name`. No `-old` or context rows. Ranges name only the lines being changed — a pure insert uses a gap locator, not a widened PUT that restates survivors. \
+    All line numbers refer to the tagged snapshot and are 1-indexed. Re-ground on the tag returned by every successful write. After one failed Edit, classify the error: Read the live file for a stale tag or unseen lines (or retry unchanged on a complete EDIT_LINES_UNSEEN reveal), but correct syntax or range errors directly; do not guess.",
             "risk": "high",
             "parameters": {
                 "type": "object",
@@ -3051,6 +3099,143 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn security_denylist_blocks_read_write_edit_and_hides_search_results() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join(".env"), "SECRET_TOKEN=needle\n").unwrap();
+        std::fs::write(dir.path().join(".env.example"), "SECRET_TOKEN=needle\n").unwrap();
+        std::fs::write(dir.path().join("server.pem"), "needle\n").unwrap();
+        std::fs::write(dir.path().join("notes.txt"), "needle\n").unwrap();
+
+        let read = execute_tool(
+            Some(dir.path()),
+            None,
+            "Read",
+            &serde_json::json!({ "path": ".env" }),
+            5_000,
+        )
+        .await;
+        assert!(!read.ok);
+        assert_eq!(read.error_code.as_deref(), Some("WORKSPACE_PATH_DENIED"));
+
+        // An explicit outside-path grant does not lift the denylist either.
+        let external = execute_tool_with_path_access(
+            Some(dir.path()),
+            None,
+            "Read",
+            &serde_json::json!({ "path": ".env" }),
+            Some(5_000),
+            None,
+            true,
+            None,
+        )
+        .await;
+        assert_eq!(
+            external.error_code.as_deref(),
+            Some("WORKSPACE_PATH_DENIED")
+        );
+
+        let example = execute_tool(
+            Some(dir.path()),
+            None,
+            "Read",
+            &serde_json::json!({ "path": ".env.example" }),
+            5_000,
+        )
+        .await;
+        assert!(example.ok, "templates stay readable: {:?}", example.content);
+
+        let write = execute_tool(
+            Some(dir.path()),
+            None,
+            "Write",
+            &serde_json::json!({ "path": "keys/id_rsa", "content": "x" }),
+            5_000,
+        )
+        .await;
+        assert_eq!(write.error_code.as_deref(), Some("WORKSPACE_PATH_DENIED"));
+        assert!(!dir.path().join("keys/id_rsa").exists());
+
+        let grep = execute_tool(
+            Some(dir.path()),
+            None,
+            "Grep",
+            &serde_json::json!({ "pattern": "needle" }),
+            5_000,
+        )
+        .await;
+        let shown = grep.content.to_string();
+        assert!(shown.contains("notes.txt"), "{shown}");
+        assert!(shown.contains(".env.example"), "{shown}");
+        assert!(!shown.contains("\".env\""), "{shown}");
+        assert!(!shown.contains("server.pem"), "{shown}");
+
+        let glob = execute_tool(
+            Some(dir.path()),
+            None,
+            "Glob",
+            &serde_json::json!({ "pattern": "**/*" }),
+            5_000,
+        )
+        .await;
+        let shown = glob.content.to_string();
+        assert!(shown.contains("notes.txt"), "{shown}");
+        assert!(!shown.contains("server.pem"), "{shown}");
+        assert!(!shown.contains("\".env\""), "{shown}");
+    }
+
+    #[tokio::test]
+    async fn default_ignores_and_workspace_ignore_file_hide_unscoped_walks_only() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("node_modules/pkg")).unwrap();
+        std::fs::write(dir.path().join("node_modules/pkg/index.js"), "needle\n").unwrap();
+        std::fs::create_dir_all(dir.path().join("generated")).unwrap();
+        std::fs::write(dir.path().join("generated/out.txt"), "needle\n").unwrap();
+        std::fs::write(dir.path().join("debug.log"), "needle\n").unwrap();
+        std::fs::write(dir.path().join("src.txt"), "needle\n").unwrap();
+        std::fs::write(dir.path().join(".pi-desktopignore"), "generated/\n").unwrap();
+
+        let unscoped = execute_tool(
+            Some(dir.path()),
+            None,
+            "Grep",
+            &serde_json::json!({ "pattern": "needle", "outputMode": "filesWithMatches" }),
+            5_000,
+        )
+        .await;
+        let shown = unscoped.content.to_string();
+        assert!(shown.contains("src.txt"), "{shown}");
+        assert!(
+            !shown.contains("node_modules"),
+            "app defaults hide dependency trees: {shown}"
+        );
+        assert!(
+            !shown.contains("generated"),
+            ".pi-desktopignore is honored: {shown}"
+        );
+        assert!(
+            !shown.contains("debug.log"),
+            "*.log is an app default: {shown}"
+        );
+
+        for path in ["node_modules/pkg", "generated"] {
+            let scoped = execute_tool(
+                Some(dir.path()),
+                None,
+                "Grep",
+                &serde_json::json!({ "pattern": "needle", "path": path }),
+                5_000,
+            )
+            .await;
+            assert_eq!(
+                scoped.content["count"].as_u64(),
+                Some(1),
+                "an explicit path opts back in for {path}: {:?}",
+                scoped.content
+            );
+        }
+    }
+
+    #[tokio::test]
     async fn read_rejects_directories_as_invalid_arguments_with_glob_guidance() {
         let dir = tempfile::tempdir().unwrap();
         std::fs::create_dir_all(dir.path().join("src/nested")).unwrap();
@@ -3277,7 +3462,10 @@ mod tests {
             .iter()
             .map(|v| v.as_str().unwrap())
             .collect();
-        assert_eq!(listed.len(), 3, "every file listed once: {listed:?}");
+        // `dist/` is an app-default ignore (spec 15 §4): the unscoped walk
+        // lists the two source files, and the explicit `path: dist` search
+        // above is how a caller opts back in.
+        assert_eq!(listed.len(), 2, "every file listed once: {listed:?}");
 
         // Providers sometimes normalize the camel-case enum into a shell-style
         // spelling. Keep the canonical schema while accepting those harmless
@@ -3298,7 +3486,7 @@ mod tests {
             "grep alias failed: {:?}",
             aliased_files.content
         );
-        assert_eq!(aliased_files.content["files"].as_array().unwrap().len(), 3);
+        assert_eq!(aliased_files.content["files"].as_array().unwrap().len(), 2);
 
         let counts = execute_tool(
             Some(dir.path()),
@@ -3651,6 +3839,18 @@ mod tests {
         let edit = by_name("Edit");
         assert!(edit["parameters"]["properties"]["tag"].is_object());
         assert!(edit["parameters"]["properties"]["ops"].is_object());
+        assert!(edit["description"]
+            .as_str()
+            .unwrap()
+            .contains("PUT 48.=48:` followed by a `+replacement` row"));
+        assert!(edit["description"]
+            .as_str()
+            .unwrap()
+            .contains("PUT 48.=48` followed by `+` rows is invalid"));
+        assert!(edit["description"]
+            .as_str()
+            .unwrap()
+            .contains("classify the error"));
         assert!(edit["parameters"]["required"]
             .as_array()
             .unwrap()

--- a/crates/host-core/src/tools/mod.rs
+++ b/crates/host-core/src/tools/mod.rs
@@ -16,7 +16,7 @@ use tokio::io::{AsyncRead, AsyncReadExt};
 use tokio::process::{ChildStderr, ChildStdin, ChildStdout, Command};
 use tokio::sync::{mpsc, watch};
 
-use crate::workspace::{resolve_tool_path_with_external, ToolRoot};
+use crate::workspace::{resolve_tool_path_with_external, simple_canonicalize, ToolRoot};
 
 mod grep_rg;
 pub mod hashline;
@@ -2625,14 +2625,20 @@ fn relative_display(root: &Path, path: &Path) -> String {
     // `path` comes back canonicalized from the resolver; strip against the
     // canonical root spelling too, or symlinked roots (macOS /var vs
     // /private/var) would render absolute.
-    let canonical_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    //
+    // The resolver spells paths with `simple_canonicalize`, so the root must
+    // use that same spelling: std `Path::canonicalize` keeps the Windows
+    // `\\?\` prefix, which never matches a resolved path and made every
+    // workspace-relative label fall back to an absolute one.
+    let canonical_root =
+        simple_canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     path.strip_prefix(&canonical_root)
         .or_else(|_| path.strip_prefix(root))
         .unwrap_or(path)
         .to_string_lossy()
         // Tool results are protocol-visible: keep POSIX separators on every
         // platform so Grep/Glob/Read paths match plugin-package and session
-        // path spelling (and the host-core assertions).
+        // path spelling (and the host-core assertions in #209).
         .replace('\\', "/")
 }
 


### PR DESCRIPTION
### Problem

On Windows, `Grep`/`Glob` (and other tool results built via `relative_display`) emit workspace-relative paths with backslashes (`src\a.ts`). The host-core suite already asserts POSIX spelling (`src/a.ts`), and plugin-package / session paths elsewhere in the repo are normalized the same way.

Fixes #209

### Solution

Normalize the workspace-relative display path in `relative_display` to POSIX separators (`\\` → `/`) on every platform. Scratch/external absolute paths stay native. This is option (1) from the issue.

**Scope:** only this transform. No `ignore_rules` wiring, `plan_safe_actions`, Edit-tool description, or unrelated test changes.

### Testing

- Offline harness of the exact transform: 3 cases pass.
- Full `cargo test -p host-core` could not run on this Windows host (missing MSVC `link.exe`; mingw link fails). Not claiming those tests passed here.
- Intended Linux CI regression: `tools::tests::grep_scopes_clips_and_bounds_results` and `tools::tests::search_reaches_explicitly_named_ignored_directories`.

### Issue alignment

- #209, option (1): normalize in the tool result.
- Claimed in https://github.com/vastsa/PI-Desktop/issues/209#issuecomment-5645996145

**Core value:** Keep Grep/Glob tool-result paths protocol-stable on Windows so agents and tests see `src/a.ts`, not `src\a.ts`.