### PR TITLE
fix(tools): emit POSIX separators in workspace-relative tool paths

### DIFF
--- a/crates/host-core/src/tools/mod.rs
+++ b/crates/host-core/src/tools/mod.rs
@@ -2585,7 +2585,10 @@ fn relative_display(root: &Path, path: &Path) -> String {
         .or_else(|_| path.strip_prefix(root))
         .unwrap_or(path)
         .to_string_lossy()
-        .to_string()
+        // Tool results are protocol-visible: keep POSIX separators on every
+        // platform so Grep/Glob/Read paths match plugin-package and session
+        // path spelling (and the host-core assertions in #209).
+        .replace('\\', "/")
 }
 
 pub fn builtin_tool_defs() -> Value {


### PR DESCRIPTION
### Problem

On Windows, `Grep`/`Glob` (and other tool results built via `relative_display`) emit workspace-relative paths with backslashes (`src\a.ts`). The host-core suite already asserts POSIX spelling (`src/a.ts`), and plugin-package / session paths elsewhere in the repo are normalized the same way.

Fixes #209

### Solution

Normalize the workspace-relative display path in `relative_display` to POSIX separators (`\\` → `/`) on every platform. Scratch/external absolute paths stay native. This is option (1) from the issue.

**Scope:** only this transform in `crates/host-core/src/tools/mod.rs`. No `ignore_rules` wiring, `plan_safe_actions`, Edit-tool description, or unrelated test changes. Supersedes #271.

### Testing

- Offline harness of the exact transform: 3 cases pass.
- Full `cargo test -p host-core` could not run on this Windows host (missing MSVC `link.exe`; mingw link fails). Not claiming those tests passed here.
- Intended Linux CI regression: `tools::tests::grep_scopes_clips_and_bounds_results` and `tools::tests::search_reaches_explicitly_named_ignored_directories`.

### Issue alignment

- #209, option (1): normalize in the tool result.
- Claimed in https://github.com/vastsa/PI-Desktop/issues/209#issuecomment-5645996145

**Core value:** Keep Grep/Glob tool-result paths protocol-stable on Windows so agents and tests see `src/a.ts`, not `src\a.ts`.