### PR TITLE
fix(importers): filter newer Codex synthetic titles and fall back to mtime

### DIFF
--- a/apps/desktop/electron/main/importers/codex.ts
+++ b/apps/desktop/electron/main/importers/codex.ts
@@ -44,13 +44,29 @@ function itemText(item: CodexItem): string {
     .trim();
 }
 
-// Codex prepends synthetic user messages carrying repo instructions/env info.
+// Codex prepends synthetic user messages carrying repo instructions, IDE
+// context, and tooling state, so the first real user message (the scan title)
+// must skip them. The list is evidence-driven from real archives (#265):
+// newer Codex builds inject an IDE-context family alongside the original
+// AGENTS.md block. Real user messages can legitimately start with "# "
+// (pasted markdown such as "# Role: …"), so matching stays on the exact
+// evidenced prefixes instead of a blanket "#" rule — extend the list when a
+// new injection shows up, one archive sample at a time.
+const SYNTHETIC_USER_PREFIXES = [
+  "<",
+  "# AGENTS.md",
+  "# Context from my IDE setup",
+  "# In app browser:",
+  "# Browser comments:",
+  "# Files mentioned by the user:",
+  "# Diff comments:",
+  "# Selected text:",
+  "# Review findings:",
+  "You are Codex",
+];
+
 function isSyntheticUserText(text: string): boolean {
-  return (
-    text.startsWith("<") ||
-    text.startsWith("# AGENTS.md") ||
-    text.startsWith("You are Codex")
-  );
+  return SYNTHETIC_USER_PREFIXES.some((prefix) => text.startsWith(prefix));
 }
 
 async function parseFile(filePath: string): Promise<ParsedCodexFile | null> {
@@ -157,6 +173,8 @@ interface CodexScanMeta {
   cwd: string | null;
   startedAt: string | null;
   lastAt: string | null;
+  /** File mtime, the honest fallback when stored timestamps are corrupt (#265). */
+  mtimeMs: number | null;
   /** Exact item count, or null when the file was too large to scan fully. */
   itemCount: number | null;
   /** Whether any item line was seen (mirrors `parsed.items.length > 0`). */
@@ -170,6 +188,7 @@ function newScanMeta(): CodexScanMeta {
     cwd: null,
     startedAt: null,
     lastAt: null,
+    mtimeMs: null,
     itemCount: 0,
     sawItem: false,
     firstUserText: null,
@@ -315,16 +334,17 @@ async function scanLargeFile(
 
 async function scanFile(filePath: string): Promise<CodexScanMeta | null> {
   let handle: fs.FileHandle;
-  let size: number;
+  let stats: Awaited<ReturnType<typeof handle.stat>>;
   try {
     handle = await fs.open(filePath, "r");
-    size = (await handle.stat()).size;
+    stats = await handle.stat();
   } catch {
     return null;
   }
   try {
-    if (size <= CODEX_SCAN_FULL_PARSE_MAX_BYTES) {
+    if (stats.size <= CODEX_SCAN_FULL_PARSE_MAX_BYTES) {
       const meta = newScanMeta();
+      meta.mtimeMs = stats.mtimeMs;
       const stream = createReadStream(filePath, { encoding: "utf8" });
       const lines = createInterface({ input: stream, crlfDelay: Infinity });
       for await (const line of lines) {
@@ -336,7 +356,9 @@ async function scanFile(filePath: string): Promise<CodexScanMeta | null> {
       if (!meta.externalId) meta.externalId = path.basename(filePath, ".jsonl");
       return meta;
     }
-    return await scanLargeFile(filePath, size, handle);
+    const meta = await scanLargeFile(filePath, stats.size, handle);
+    if (meta) meta.mtimeMs = stats.mtimeMs;
+    return meta;
   } catch {
     return null;
   } finally {
@@ -352,14 +374,18 @@ export async function scanCodexSessions(
   for (const filePath of files) {
     const meta = await scanFile(filePath);
     if (!meta || meta.firstUserText === null) continue;
+    // A corrupt or out-of-range stored timestamp must not rewrite the
+    // session's history to the import moment (#265): the file's own mtime is
+    // the honest fallback for both ends.
+    const fileTime = toIso(meta.mtimeMs);
     summaries.push({
       source: "codex",
       externalId: meta.externalId,
       title: truncateTitle(meta.firstUserText) || meta.externalId,
       projectPath: meta.cwd,
       model: null,
-      createdAt: toIso(meta.startedAt),
-      updatedAt: toIso(meta.lastAt, toIso(meta.startedAt)),
+      createdAt: toIso(meta.startedAt, fileTime),
+      updatedAt: toIso(meta.lastAt, toIso(meta.startedAt, fileTime)),
       messageCount: meta.itemCount,
       filePath,
     });

--- a/apps/desktop/electron/main/importers/types.ts
+++ b/apps/desktop/electron/main/importers/types.ts
@@ -60,6 +60,15 @@ export function toIso(value: string | number | undefined | null, fallback?: stri
   if (value !== undefined && value !== null) {
     const d = new Date(value);
     if (!Number.isNaN(d.getTime())) return d.toISOString();
+    // A provided-but-invalid timestamp is data corruption (truncated jsonl,
+    // out-of-range numbers): surface it instead of silently rewriting the
+    // session's history to the import moment (#265). Absent values stay
+    // silent — those are normal in optional fields.
+    console.warn(
+      `[importers] unparsable timestamp ${JSON.stringify(value)}; using ${
+        fallback ? "the provided fallback" : "the import time"
+      }`,
+    );
   }
   return fallback ?? new Date().toISOString();
 }

--- a/apps/desktop/test/importer-codex-scan.test.mjs
+++ b/apps/desktop/test/importer-codex-scan.test.mjs
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, utimes } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { register } from "node:module";
@@ -270,6 +270,108 @@ test("sampled updatedAt uses top-level timestamps only", async () => {
     async (dir) => {
       const [s] = await scanCodexSessions(dir);
       assert.equal(s.updatedAt, iso("2026-06-01T00:00:01Z"));
+    },
+  );
+});
+
+test("newer IDE-context synthetic prefixes fall through to the first real user message", async () => {
+  // #265: 214/777 real sessions (27.5%) titled "# Context from my IDE setup:
+  // ## Active file …" because only the original AGENTS.md prefix was filtered.
+  const idePrefixes = [
+    "# Context from my IDE setup:  ## Active file: App.tsx",
+    "# In app browser: - The user has the in-app browser open.",
+    "# Files mentioned by the user:  ## notes.md",
+    "# Diff comments:  ## Comment 1 File: src/a.ts",
+    "# Selected text:  ## Selection 1",
+    "# Review findings:  ## Finding 1",
+  ];
+  for (const [index, prefix] of idePrefixes.entries()) {
+    await withArchive(
+      [
+        [
+          `ide-${index}.jsonl`,
+          [
+            metaLine(`ide-${index}`, "/repo/ide", "2026-05-01T00:00:00Z"),
+            responseItem("user", prefix, "2026-05-01T00:00:01Z"),
+            responseItem("user", "帮我看看这个报错", "2026-05-01T00:00:02Z"),
+          ].join("\n"),
+        ],
+      ],
+      async (dir) => {
+        const [s] = await scanCodexSessions(dir);
+        assert.equal(s.title, "帮我看看这个报错", `prefix: ${prefix}`);
+      },
+    );
+  }
+});
+
+test("real markdown first messages survive even when they start with #", async () => {
+  // A blanket "#" rule would erase genuinely user-pasted prompts (#265).
+  await withArchive(
+    [
+      [
+        "role.jsonl",
+        [
+          metaLine("role-1", "/repo/role", "2026-05-02T00:00:00Z"),
+          responseItem("user", "# Role: 资深 Java 后端开发工程师\n\n## Profile", "2026-05-02T00:00:01Z"),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      const [s] = await scanCodexSessions(dir);
+      assert.match(s.title, /^# Role: 资深 Java 后端开发工程师/);
+    },
+  );
+});
+
+test("corrupt stored timestamps fall back to the file mtime, not the import time", async () => {
+  await withArchive(
+    [
+      [
+        "corrupt.jsonl",
+        [
+          metaLine("corrupt-1", "/repo/corrupt", "1e309"),
+          responseItem("user", "时间戳坏掉的会话", "not-a-date"),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      // Pin the file's mtime so the expected fallback is deterministic.
+      const filePath = join(dir, "corrupt.jsonl");
+      const mtime = new Date("2024-05-01T08:00:00Z");
+      await utimes(filePath, mtime, mtime);
+      const [s] = await scanCodexSessions(dir);
+      assert.equal(s.createdAt, iso(mtime));
+      assert.equal(s.updatedAt, iso(mtime));
+    },
+  );
+});
+
+test("the sampled path also falls back to the file mtime", async () => {
+  await withArchive(
+    [
+      [
+        "big-corrupt.jsonl",
+        [
+          metaLine("big-corrupt-1", "/repo/big-corrupt", "not-a-date"),
+          responseItem("user", "大文件坏时间戳", "1e309"),
+          fillBytes(
+            CODEX_SCAN_FULL_PARSE_MAX_BYTES + 512 * 1024,
+            JSON.stringify({
+              type: "response_item",
+              payload: { type: "function_call_output", call_id: "c1", output: "pad" },
+            }),
+          ),
+        ].join("\n"),
+      ],
+    ],
+    async (dir) => {
+      const filePath = join(dir, "big-corrupt.jsonl");
+      const mtime = new Date("2024-06-01T09:30:00Z");
+      await utimes(filePath, mtime, mtime);
+      const [s] = await scanCodexSessions(dir);
+      assert.equal(s.createdAt, iso(mtime));
+      assert.equal(s.updatedAt, iso(mtime));
     },
   );
 });

--- a/docs/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/spec/03-runtime/01-ipc-protocol.md
@@ -793,7 +793,12 @@ Import candidates carry `projectPath: string | null` and
 importer's sampled-scan threshold; larger files are sampled (head + tail) so
 scanning a multi-gigabyte archive stays interactive, and their `messageCount`
 is null — the import list renders an em dash for it, while imported sessions
-always compute their real message count at convert time. A successful import
+always compute their real message count at convert time. Scan titles come
+from the first real user message: known synthetic injections (repo
+instructions, the IDE-context family such as `# Context from my IDE setup:`
+or `# Browser comments:`) are skipped, while pasted markdown starting with
+`#` is kept. A corrupt or out-of-range stored timestamp falls back to the
+source file's mtime, never to the import moment. A successful import
 refreshes both sessions and the durable Projects index.
 
 `modelConfig/importScan` reads Claude Code, Codex, OpenCode, Pi, and CC

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -10379,3 +10379,29 @@ sample extensions under `apps/desktop/test/fixtures/pi-extensions/`.
   `project-import-archive.test.mjs`, `plugin-session-refresh.test.mjs`);
   rendered desktop journey Draft (run only in a capable environment when this
   surface changes)
+
+#### E2E-IMPORT-codex-scan-filters-synthetic-titles
+
+- **Preconditions**: A Codex archive whose sessions open with synthetic
+  injections (`# Context from my IDE setup:`, `# In app browser:`,
+  `# Browser comments:`, `# Files mentioned by the user:`,
+  `# Diff comments:`, `# Selected text:`, `# Review findings:`,
+  `# AGENTS.md`, `You are Codex`, `<environment>`) and at least one session
+  whose stored timestamps are corrupt or out of range.
+- **Steps**:
+  1. Run Settings → Session import → Scan over the archive.
+  2. Inspect candidate titles and the createdAt/updatedAt shown per session.
+  3. Import a session whose first real user message follows synthetic
+     injections.
+- **Expected**: Candidate titles come from the first real user message —
+  synthetic injections never surface as titles, while genuinely pasted
+  markdown that starts with `#` (for example `# Role: …`) is kept. Sessions
+  whose user messages are all synthetic do not appear as candidates. A
+  corrupt or out-of-range stored timestamp falls back to the source file's
+  mtime, never to the import moment.
+- **Specs linked**: `03-runtime/01-ipc-protocol.md`,
+  `04-ux/06-settings-ia.md`, D320
+- **Acceptance**: C (conversation & stream), F (persistence), Quality
+- **Milestone**: M6+
+- **Status**: Unit-covered (`importer-codex-scan.test.mjs`); UI journey Draft
+  (run only in a capable environment when this surface changes)

--- a/docs/zh-CN/spec/03-runtime/01-ipc-protocol.md
+++ b/docs/zh-CN/spec/03-runtime/01-ipc-protocol.md
@@ -680,7 +680,11 @@ Electron 主进程用该会话精确 provider/API URL 与 model 的本地 models
 `messageCount: number | null`。扫描对每个源文件全量读取的上限为导入器的
 采样阈值；超过阈值的文件只做采样（头部 + 尾部），使多吉字节归档的扫描
 保持可交互，其 `messageCount` 为 null——导入列表对它渲染破折号，而导入
-后的会话总是在 convert 阶段计算真实的消息数。导入成功
+后的会话总是在 convert 阶段计算真实的消息数。扫描标题取自第一条真实用户
+消息：已知的合成注入（仓库指令、`# Context from my IDE setup:`、
+`# Browser comments:` 等 IDE 上下文家族）会被跳过，而以 `#` 开头的真实
+粘贴内容予以保留。损坏或越界的存储时间戳回退到源文件的 mtime，绝不回退
+到导入时刻。导入成功
 刷新会话和持久项目索引。
 
 重新生成或编辑重发会在追加新的用户回合前截断持久转录本。`agent/prompt`

--- a/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
@@ -6601,3 +6601,16 @@ IPC 请求无法关闭。
 - **验收**：C（对话与流）、F（持久化）、G（插件）、品质
 - **里程碑**：M6+
 - **状态**：由源代码契约与单元测试覆盖（`sidebar-session-groups.test.mjs`、`project-import-archive.test.mjs`、`plugin-session-refresh.test.mjs`）；渲染桌面旅程为草稿（适用变更合入前需在具备条件的环境中运行 E2E）
+
+#### E2E-IMPORT-codex-scan-filters-synthetic-titles
+
+- **前提条件**：一个 Codex 归档，其中的会话以合成注入开头（`# Context from my IDE setup:`、`# In app browser:`、`# Browser comments:`、`# Files mentioned by the user:`、`# Diff comments:`、`# Selected text:`、`# Review findings:`、`# AGENTS.md`、`You are Codex`、`<environment>`），且至少一个会话的存储时间戳损坏或越界。
+- **步骤**：
+  1. 对该归档运行设置 → 会话导入 → 扫描。
+  2. 检查候选会话的标题与每条会话展示的 createdAt/updatedAt。
+  3. 导入一个首条真实用户消息位于合成注入之后的会话。
+- **预期**：候选标题取自第一条真实用户消息——合成注入绝不作为标题出现，而以 `#` 开头的真实粘贴内容（例如 `# Role: …`）予以保留。用户消息全为合成的会话不作为候选出现。损坏或越界的存储时间戳回退到源文件的 mtime，绝不回退到导入时刻。
+- **链接规格**：`03-runtime/01-ipc-protocol.md`、`04-ux/06-settings-ia.md`、D320
+- **验收**：C（对话与流）、F（持久化）、品质
+- **里程碑**：M6+
+- **状态**：由单元测试覆盖（`importer-codex-scan.test.mjs`）；UI 旅程为草稿（该表面变更时需在具备条件的环境中运行）


### PR DESCRIPTION
## What

Two data-quality fixes in the Codex importer, from issue #265's real-archive findings:

**1. Synthetic-title filter catches the newer IDE-context family.** The filter only knew the original AGENTS.md preamble, so sessions opening with `# Context from my IDE setup: ## Active file …` kept that noise as their title — on a real 865-file / 2.6GB archive that was **214 sessions (27.5%)**. An evidence pass over the same archive surfaced the family's siblings and they are all filtered now:

`# In app browser:`, `# Browser comments:`, `# Files mentioned by the user:`, `# Diff comments:`, `# Selected text:`, `# Review findings:`

**2. Corrupt timestamps no longer rewrite history.** `toIso` used to map a provided-but-invalid timestamp (truncated jsonl lines, out-of-range numbers like `1e309`) to the **import moment**, silently drifting a session's history. Scans now fall back to the source file's mtime for both `createdAt` and `updatedAt`, and a provided-but-unparsable value logs a warning instead of vanishing. Absent (optional) values keep the old silent behavior so legit bulk scans don't spam.

## Deliberately not changed

- **No blanket `#` rule.** Real users paste markdown that starts with `#` — the same archive carries 18 sessions with a `# Role: 资深 Java 后端开发工程师` prompt pasted mid-conversation and 2 whose genuine first message is a pasted article title. Matching stays on the exact evidenced prefixes; the list is commented as evidence-driven so future injections extend it one sample at a time.
- The D320/D322 boundaries, the sampled-scan contract (messageCount `null`), and convert-time exact counts are untouched.

## Verification

- Real-archive before/after (865 files / 2.6GB, local): **before** 777 candidates with 214+ IDE-noise titles; **after** 604 candidates (sessions whose user messages are all synthetic are correctly skipped), **0 IDE-family titles remain**, and the 2 remaining `#`-titles are genuine user-pasted content.
- `importer-codex-scan.test.mjs`: 5 new regressions (each evidenced prefix falls through to the first real message; `# Role:` markdown kept; corrupt timestamps → mtime fallback on both the full-parse and sampled paths) — 11/11 green; full local gates green (build, desktop typecheck, style-token lint, `pnpm -r test` 1449/1449, architecture budgets).
- Docs: the session-import contract paragraph in `03-runtime/01-ipc-protocol.md` (en + zh-CN) records the title filtering and mtime fallback; new scenario `E2E-IMPORT-codex-scan-filters-synthetic-titles` added to the E2E plan (en + zh-CN), prose-only so table/fence parity holds.
- E2E disposition per AGENTS §15 (fork PR):

```
E2E: NOT RUN
Suite: no listed suite drives the import scan surface
Reason: renderer-adjacent main-process parsing; verified against a real 865-file archive plus unit regressions
Alternative validation: real-archive before/after counts above (scan results, titles, timestamps)
Remaining risk: future Codex versions may inject new synthetic prefixes; the list is the extension point
```

Fixes #265