### PR TITLE
fix(desktop): show read line ranges in tool chips

### DIFF
--- a/apps/desktop/src/components/ToolDetails.tsx
+++ b/apps/desktop/src/components/ToolDetails.tsx
@@ -256,6 +256,7 @@ const CHIP_LABEL_KEYS: Record<ToolChip["role"], string> = {
   replacements: "chat.toolChipReplacements",
   truncated: "chat.toolChipTruncated",
   scratch: "chat.toolChipScratch",
+  lines: "chat.toolChipLines",
   size: "chat.toolChipSize",
 };
 
@@ -272,7 +273,11 @@ export function ToolChips({ chips }: { chips: ToolChip[] }) {
         >
           {t(CHIP_LABEL_KEYS[chip.role], {
             ...("count" in chip ? { count: chip.count } : {}),
-            ...("text" in chip ? { size: chip.text } : {}),
+            ...("text" in chip
+              ? chip.role === "lines"
+                ? { range: chip.text }
+                : { size: chip.text }
+              : {}),
           })}
         </span>
       ))}

--- a/apps/desktop/src/lib/tool-presentation.ts
+++ b/apps/desktop/src/lib/tool-presentation.ts
@@ -45,6 +45,7 @@ export type ToolPresentationMessage = {
 export type ToolChip =
   | { role: "exit" | "matches" | "files" | "replacements"; count: number }
   | { role: "truncated" | "scratch" }
+  | { role: "lines"; text: string }
   | { role: "size"; text: string };
 
 export type ToolBlockRole =
@@ -270,6 +271,25 @@ function formatBytes(bytes: number): string {
   return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function formatReadLineRange(details: Record<string, unknown>): string | null {
+  const offset = numberAt(details, "offset");
+  const lineCount = numberAt(details, "lineCount");
+  if (
+    offset === null ||
+    lineCount === null ||
+    !Number.isSafeInteger(offset) ||
+    !Number.isSafeInteger(lineCount) ||
+    offset < 0 ||
+    lineCount <= 0
+  ) {
+    return null;
+  }
+  const end = offset + lineCount;
+  return Number.isSafeInteger(end)
+    ? `${lineCount},L${offset + 1}-L${end}`
+    : null;
+}
+
 /**
  * Minimal line diff used by review hunks and tests. Both sides are localized
  * snippets, so trimming the shared head/tail to a little context is enough to
@@ -483,8 +503,13 @@ export function toolResultChips(message: ToolPresentationMessage): ToolChip[] {
   if (replacements !== null && replacements > 0) {
     chips.push({ role: "replacements", count: replacements });
   }
-  const bytes = numberAt(details, "bytes") ?? numberAt(details, "fileBytes");
-  if (bytes !== null) chips.push({ role: "size", text: formatBytes(bytes) });
+  if (action === "read") {
+    const lineRange = formatReadLineRange(details);
+    if (lineRange !== null) chips.push({ role: "lines", text: lineRange });
+  } else {
+    const bytes = numberAt(details, "bytes") ?? numberAt(details, "fileBytes");
+    if (bytes !== null) chips.push({ role: "size", text: formatBytes(bytes) });
+  }
   if (details.truncated === true) chips.push({ role: "truncated" });
   if (details.root === "scratch") chips.push({ role: "scratch" });
   return chips;

--- a/apps/desktop/test/tool-presentation.test.mjs
+++ b/apps/desktop/test/tool-presentation.test.mjs
@@ -322,7 +322,7 @@ test("Grep's other output modes and host notices stay readable", () => {
   assert.match(noticed[1].text, /raise limit/);
 });
 
-test("a paginated Read window keeps its content, size and notice", () => {
+test("a paginated Read window shows its line range and notice", () => {
   const message = {
     toolName: "Read",
     toolArgs: { path: "big.txt", offset: 200, limit: 2 },
@@ -342,9 +342,44 @@ test("a paginated Read window keeps its content, size and notice", () => {
   assert.deepEqual(roles(blocks), ["content", "notice"]);
   assert.equal(blocks[0].text, "line 201\nline 202");
   assert.deepEqual(toolResultChips(message), [
-    { role: "size", text: "2.0 KB" },
+    { role: "lines", text: "2,L201-L202" },
     { role: "truncated" },
   ]);
+});
+
+test("a complete Read window uses its returned line count, not file size", () => {
+  const message = {
+    toolName: "Read",
+    toolArgs: { path: "small.txt" },
+    toolResult: envelope({
+      path: "small.txt",
+      root: "workspace",
+      content: "line 1\nline 2\nline 3",
+      offset: 0,
+      lineCount: 3,
+      totalLines: 3,
+      fileBytes: 169_600,
+      truncated: false,
+    }),
+  };
+
+  assert.deepEqual(toolResultChips(message), [
+    { role: "lines", text: "3,L1-L3" },
+  ]);
+});
+
+test("a historical Read without line metadata does not fake a size chip", () => {
+  assert.deepEqual(
+    toolResultChips({
+      toolName: "Read",
+      toolResult: envelope({
+        path: "legacy.txt",
+        content: "1: legacy line",
+        fileBytes: 2048,
+      }),
+    }),
+    [],
+  );
 });
 
 test("a failed tool leads with the error note and keeps the arguments", () => {

--- a/docs/spec/04-ux/08-component-spec.md
+++ b/docs/spec/04-ux/08-component-spec.md
@@ -1655,10 +1655,15 @@ seconds when non-zero) from one hour onward. Zero-value units are omitted, so
   not the raw function name. Running actions use the progressive form.
 - The primary argument is a clamped single-line monospace hint.
 - Result chips follow the hint: exit code (error hue), match/file counts,
-  replacement count, written or read size, `truncated`, `scratch`. A successful
-  exit earns no chip — the row status already says so. The `truncated` chip
-  follows `details.truncated` and therefore appears only when this result was
-  cut short, not when a Read window of a longer file was filled (D306).
+  replacement count, Write byte size, Read line count plus its 1-based closed
+  line range (`{lineCount},L{offset+1}-L{offset+lineCount}`), `truncated`, and
+  `scratch`. Read uses `offset` and `lineCount` from the returned window rather
+  than `fileBytes`; if those fields are unavailable, it omits the read-size
+  chip instead of presenting the whole-file size as the amount read. A
+  successful exit earns no chip — the row status already says so. The
+  `truncated` chip follows `details.truncated` and therefore appears only when
+  this result was cut short, not when a Read window of a longer file was filled
+  (D306).
 - Live activity remains in the processing group, its latest row, or the
   dedicated runtime indicator; no additional status capsule is rendered.
   Long paths remain in the row summary and are ellipsized.

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -5387,6 +5387,10 @@ needed.
     a path list; Grep shows hits grouped per file with line numbers in `content`
     mode, a path list in `filesWithMatches`, and per-file totals in `count`; the
     failing command carries an `exit 1` chip.
+  - A Read row's collapsed chip shows the returned window as
+    `{lineCount},L{offset+1}-L{offset+lineCount}` (for example,
+    `50,L16-L65`), never `fileBytes`; a Read result without valid window
+    metadata has no size chip. Write continues to show its byte-size chip.
   - Each Glob/Grep path-list row is start-aligned with natural character
     spacing; glyphs are not distributed across the block width.
   - The workspace edit shows no inline diff (its ReviewChangeCard owns it); the

--- a/packages/i18n/src/locales/de/index.ts
+++ b/packages/i18n/src/locales/de/index.ts
@@ -352,6 +352,7 @@ export const de = {
     "toolChipReplacements_other": "{{count}} Ersatz",
     "toolChipTruncated": "abgeschnitten",
     "toolChipScratch": "Scratch",
+    "toolChipLines": "{{range}}",
     "toolChipSize": "{{size}}",
     "toolRead": "Lesen",
     "toolListed": "Aufgelistet",

--- a/packages/i18n/src/locales/en/index.ts
+++ b/packages/i18n/src/locales/en/index.ts
@@ -359,6 +359,7 @@ export const en = {
     toolChipReplacements_other: "{{count}} replacements",
     toolChipTruncated: "truncated",
     toolChipScratch: "scratch",
+    toolChipLines: "{{range}}",
     toolChipSize: "{{size}}",
     toolRead: "Read",
     toolListed: "Listed",

--- a/packages/i18n/src/locales/es/index.ts
+++ b/packages/i18n/src/locales/es/index.ts
@@ -352,6 +352,7 @@ export const es = {
     "toolChipReplacements_other": "{{count}} reemplazos",
     "toolChipTruncated": "truncado",
     "toolChipScratch": "scratch",
+    "toolChipLines": "{{range}}",
     "toolChipSize": "{{size}}",
     "toolRead": "Leído",
     "toolListed": "Listado",

--- a/packages/i18n/src/locales/fr/index.ts
+++ b/packages/i18n/src/locales/fr/index.ts
@@ -352,6 +352,7 @@ export const fr = {
     "toolChipReplacements_other": "{{count}} remplacements",
     "toolChipTruncated": "tronqué",
     "toolChipScratch": "scratch",
+    "toolChipLines": "{{range}}",
     "toolChipSize": "{{size}}",
     "toolRead": "Lire",
     "toolListed": "Répertorié",

--- a/packages/i18n/src/locales/ko/index.ts
+++ b/packages/i18n/src/locales/ko/index.ts
@@ -361,6 +361,7 @@ export const ko = {
     toolChipReplacements_other: "교체 {{count}}개",
     toolChipTruncated: "잘림",
     toolChipScratch: "임시",
+    toolChipLines: "{{range}}",
     toolChipSize: "{{size}}",
     toolRead: "읽음",
     toolListed: "목록 표시됨",

--- a/packages/i18n/src/locales/tr/index.ts
+++ b/packages/i18n/src/locales/tr/index.ts
@@ -361,6 +361,7 @@ export const tr = {
     toolChipReplacements_other: "{{count}} değişiklik",
     toolChipTruncated: "kesildi",
     toolChipScratch: "geçici",
+    toolChipLines: "{{range}}",
     toolChipSize: "{{size}}",
     toolRead: "Okundu",
     toolListed: "Listelendi",

--- a/packages/i18n/src/locales/zh-CN/index.ts
+++ b/packages/i18n/src/locales/zh-CN/index.ts
@@ -354,6 +354,7 @@ export const zhCN = {
     toolChipReplacements_other: "替换 {{count}} 处",
     toolChipTruncated: "已截断",
     toolChipScratch: "临时目录",
+    toolChipLines: "{{range}}",
     toolChipSize: "{{size}}",
     toolRead: "读取",
     toolListed: "列出",

--- a/packages/i18n/src/locales/zh-TW/index.ts
+++ b/packages/i18n/src/locales/zh-TW/index.ts
@@ -354,6 +354,7 @@ export const zhTW = {
     toolChipReplacements_other: "替換 {{count}} 處",
     toolChipTruncated: "已截斷",
     toolChipScratch: "臨時目錄",
+    toolChipLines: "{{range}}",
     toolChipSize: "{{size}}",
     toolRead: "讀取",
     toolListed: "列出",


### PR DESCRIPTION
## Summary

- Show Read result chips as `{lineCount},L{start}-L{end}` from the returned window metadata.
- Keep Write and other byte-oriented tool chips unchanged.
- Omit the Read amount chip when historical results lack valid line metadata.
- Update locale keys, the component spec, and E2E-145 expectations.

## Validation

- `node --test test/tool-presentation.test.mjs` (30/30)
- `pnpm --filter @pi-desktop/desktop test` (1451/1451)
- `pnpm --filter @pi-desktop/i18n test` (23/23)
- `pnpm build:js`
- `pnpm typecheck`
- `pnpm lint`
- Local E2E not run per Issue #279 repository guidance; E2E-145 was updated for CI coverage.

Closes #279