### PR TITLE
test(platform): preserve shell-output and symlink coverage on Windows

### DIFF
--- a/crates/host-core/src/tools/mod.rs
+++ b/crates/host-core/src/tools/mod.rs
@@ -2931,18 +2931,26 @@ mod tests {
         let data = tempfile::tempdir().unwrap();
         let scratch = data.path().join("scratch/session-spill");
         let lines = BUDGET_SHELL.max_lines + 500;
+        #[cfg(windows)]
+        let command = format!("1..{lines} | ForEach-Object {{ [Console]::Out.WriteLine($_) }}");
+        #[cfg(not(windows))]
+        let command = format!("seq 1 {lines}");
         let result = execute_tool(
             Some(ws.path()),
             Some(&scratch),
             "Bash",
-            &serde_json::json!({ "command": format!("seq 1 {lines}") }),
+            &serde_json::json!({ "command": command }),
             30_000,
         )
         .await;
         assert!(result.ok, "bash tool failed: {:?}", result.content);
         assert_eq!(result.content["truncated"].as_bool(), Some(true));
         let stdout = result.content["stdout"].as_str().unwrap();
-        assert!(stdout.starts_with("1\n2\n"), "head retained");
+        assert_eq!(
+            stdout.lines().take(2).collect::<Vec<_>>(),
+            ["1", "2"],
+            "head retained"
+        );
         assert!(stdout.contains("[truncated:"), "marker present");
 
         // The marker names a spill file that holds the whole output.
@@ -2963,17 +2971,23 @@ mod tests {
         // A failing command's actionable message is its last line.
         let ws = tempfile::tempdir().unwrap();
         let lines = BUDGET_SHELL_ERR.max_lines + 200;
+        #[cfg(windows)]
+        let command = format!(
+            "1..{lines} | ForEach-Object {{ [Console]::Error.WriteLine($_) }}; [Console]::Error.WriteLine('error: the real problem'); exit 2"
+        );
+        #[cfg(not(windows))]
+        let command = format!("seq 1 {lines} >&2; printf 'error: the real problem\\n' >&2; exit 2");
         let result = execute_tool(
             Some(ws.path()),
             None,
             "Bash",
-            &serde_json::json!({
-                "command": format!("seq 1 {lines} >&2; printf 'error: the real problem\\n' >&2; exit 2")
-            }),
+            &serde_json::json!({ "command": command }),
             30_000,
         )
         .await;
         assert!(!result.ok);
+        assert_eq!(result.content["exitCode"].as_i64(), Some(2));
+        assert_eq!(result.content["truncated"].as_bool(), Some(true));
         let stderr = result.content["stderr"].as_str().unwrap();
         assert!(
             stderr.trim_end().ends_with("error: the real problem"),

--- a/packages/plugin-devkit/src/templates.test.ts
+++ b/packages/plugin-devkit/src/templates.test.ts
@@ -212,7 +212,16 @@ describe("check", () => {
 
   it("rejects symlinks, which host-core refuses to copy", async () => {
     const dir = await scaffolded("panel-basic");
-    await symlink(join(dir, "main.js"), join(dir, "link.js"));
+    try {
+      await symlink(join(dir, "main.js"), join(dir, "link.js"));
+    } catch (error) {
+      if (process.platform !== "win32" || (error as NodeJS.ErrnoException).code !== "EPERM") {
+        throw error;
+      }
+      // Windows file symlinks need Developer Mode or elevation; junctions do not.
+      // Both are reported as symbolic links by the package walker's Dirent check.
+      await symlink(join(dir, "renderer"), join(dir, "link-renderer"), "junction");
+    }
     expect((await check(dir)).errors.map((e) => e.code)).toContain("package.symlink");
   });
 


### PR DESCRIPTION
The shell-output tests currently run POSIX commands even when the Windows runner selects PowerShell, and the plugin link-rejection test fails before its assertion on Windows without file-symlink privileges.

Use platform-specific output commands while keeping the stderr tail, truncation, exit-code, and stdout spill assertions. Accept CRLF when checking the first output lines. In the DevKit test, fall back to a directory junction only when Windows rejects file-symlink creation with `EPERM`; other failures remain errors and the link-rejection assertion still runs.

Closes #210.

Validation on macOS ARM64 at `2bc0df9`:

- Plugin DevKit: 46 tests passed; TypeScript typecheck passed.
- Rust focused tests `bash_stderr_keeps_the_tail` and `bash_over_budget_output_spills_to_scratch`: passed.
- `cargo fmt --check` and `git diff --check`: passed.

This change only modifies tests; production behavior and contracts are unchanged. Windows-native execution has not been performed and remains a validation limitation. Product E2E was not run for this test-only branch.
