### PR TITLE
fix(subagents): 子代理完成后立即更新并持久化 Task 状态

### DIFF
--- a/apps/desktop/electron/main/persistence-outbox.ts
+++ b/apps/desktop/electron/main/persistence-outbox.ts
@@ -95,7 +95,9 @@ export class PersistenceOutbox {
         });
         return;
       }
-      this.entries.shift();
+      // A newer snapshot may have replaced this key while the host wrote it.
+      // Only remove the exact entry acknowledged by that write.
+      if (this.entries[0] === current) this.entries.shift();
       await this.persist();
     }
   }

--- a/apps/desktop/electron/main/runtime/event-persistence.ts
+++ b/apps/desktop/electron/main/runtime/event-persistence.ts
@@ -236,6 +236,26 @@ function persistAgentEvent(envelope: AgentEventEnvelope): UiMessage | undefined 
         }),
       );
   }
+  // Runtime settlement refreshes the original Task row through the existing
+  // full-message event; persist it as well as updating the live renderer.
+  if (event.type === "message_end" && event.message.role === "tool") {
+    void persistenceOutbox
+      .enqueue(
+        {
+          key: `message:${envelope.sessionId}:${event.message.id}`,
+          sessionId: envelope.sessionId,
+          message: subagentTagged(event.message, envelope),
+          turnId: envelope.turnId ?? turnId,
+        },
+        () => runtimeState.host,
+      )
+      .catch((error) =>
+        logger.app("persistence", "warn", "tool snapshot persistence enqueue failed", {
+          sessionId: envelope.sessionId,
+          data: String(error),
+        }),
+      );
+  }
   if (event.type === "tool_end") {
     const key = activeToolCallKey(envelope.sessionId, event.toolCallId);
     const started = activeToolCalls.get(key);

--- a/apps/desktop/src/lib/subagent-topology.ts
+++ b/apps/desktop/src/lib/subagent-topology.ts
@@ -176,11 +176,12 @@ export function delegationTimingBounds(
 }
 
 /**
- * Latest status per delegation id, read from the lifecycle tools' results.
+ * Latest status per delegation id, from Task snapshots and lifecycle results.
  *
  * `Task` returns the moment the delegate starts (ADR 0089), so its own result
- * says `running` for the rest of the transcript no matter how the delegate
- * ended. TaskWait/TaskList report `details.delegations[]`; TaskStop reports
+ * initially says `running`. The runtime later refreshes that Task row with
+ * its terminal status, independently of parent lifecycle polling.
+ * TaskWait/TaskList report `details.delegations[]`; TaskStop reports
  * `details.stopped[]`. Those rows — which are deliberately not topology nodes —
  * are what tells a delegation card how its subagent actually finished.
  *
@@ -204,6 +205,18 @@ export function collectDelegationStatuses(
     ingestLifecycleStatuses(statuses, payload.delegations, false);
     ingestLifecycleStatuses(statuses, payload.stopped, true);
   }
+  // The runtime refreshes Task itself as soon as its delegate settles. This
+  // terminal snapshot outranks an older TaskList/TaskWait running snapshot,
+  // even though those lifecycle rows appear later in transcript order.
+  for (const item of items) {
+    if (!isDelegationActivityItem(item)) continue;
+    const payload = asRecord(toolResultPayload(item.message));
+    const status = asDelegationStatus(payload?.status);
+    const id = payload?.delegationId;
+    if (typeof id === "string" && id && status && status !== "running") {
+      statuses.set(id, status);
+    }
+  }
   if (options?.turnLive === false) {
     for (const item of items) {
       if (item.kind !== "tool" || !isDelegationActivityItem(item)) continue;
@@ -220,8 +233,9 @@ export function collectDelegationStatuses(
 /**
  * A settled subagent's failure as the runtime reported it.
  *
- * `Task` returns the moment a delegate starts (ADR 0089), so its own result can
- * never carry one. `TaskWait`/`TaskList` report `details.delegations[]` and
+ * `Task` initially returns when a delegate starts (ADR 0089); its refreshed
+ * terminal snapshot can carry a failure even before the parent polls.
+ * `TaskWait`/`TaskList` report `details.delegations[]` and
  * `TaskStop` reports `details.stopped[]`, and those entries do carry
  * `error: { code, message }` from `SubagentRunResult.error`.
  */
@@ -271,6 +285,13 @@ export function collectDelegationFailures(
         if (failure) failures.set(id, failure);
       }
     }
+  }
+  for (const item of items) {
+    if (!isDelegationActivityItem(item)) continue;
+    const payload = asRecord(toolResultPayload(item.message));
+    const id = payload?.delegationId;
+    const failure = readDelegationFailure(payload);
+    if (typeof id === "string" && id && failure) failures.set(id, failure);
   }
   return failures;
 }

--- a/apps/desktop/test/subagent-settlement-persistence.test.mjs
+++ b/apps/desktop/test/subagent-settlement-persistence.test.mjs
@@ -1,0 +1,96 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { register } from "node:module";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+
+register(new URL("./helpers/ts-import-hooks.mjs", import.meta.url));
+const { createEventPersistence } = await import("../electron/main/runtime/event-persistence.ts");
+const { PersistenceOutbox } = await import("../electron/main/persistence-outbox.ts");
+
+test("a settled Task snapshot survives outbox recovery with its original turn and metadata", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-subagent-settlement-"));
+  const silent = () => undefined;
+  try {
+    const persistenceOutbox = new PersistenceOutbox(dir, silent);
+    const queued = [];
+    const enqueue = persistenceOutbox.enqueue.bind(persistenceOutbox);
+    persistenceOutbox.enqueue = (...args) => {
+      const pending = enqueue(...args);
+      queued.push(pending);
+      return pending;
+    };
+    const { persistAgentEvent } = createEventPersistence({
+      runtimeState: { host: null },
+      activeTurns: new Map([["session", "newer-turn"]]),
+      activeToolCalls: new Map(),
+      activeToolCallKey: (sessionId, toolCallId) => `${sessionId}:${toolCallId}`,
+      approvedExecutionIdsBySession: new Map(),
+      approvedExecutionTurns: new Map(),
+      pendingExecutionFinishes: new Map(),
+      planSubmissionTurnIds: new Set(),
+      persistenceOutbox,
+      logger: { app: silent },
+    });
+    const message = {
+      id: "task-call", role: "tool", toolName: "Task", toolCallId: "task-call",
+      toolArgs: { agent: "explorer", task: "Inspect the code" },
+      toolStatus: "success", status: "complete", content: "completed",
+      createdAt: "2026-09-13T00:00:00.000Z", toolDurationMs: 5,
+      toolUsage: { inputTokens: 12, outputTokens: 3, totalTokens: 15 },
+      toolResult: { details: { delegationId: "delegate", status: "completed", completedAt: 1000 } },
+    };
+    persistAgentEvent({ sessionId: "session", turnId: "original-turn", ts: 1000,
+      event: { type: "message_end", message } });
+    await Promise.all(queued);
+    await persistenceOutbox.flush(() => null);
+    assert.equal(persistenceOutbox.size(), 1);
+    const recovered = new PersistenceOutbox(dir, silent);
+    const writes = [];
+    await recovered.flush(() => ({ isAvailable: () => true, call: async (method, params) => {
+      writes.push({ method, params });
+      return {};
+    } }));
+    assert.equal(recovered.size(), 0);
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0].method, "session.appendMessage");
+    assert.equal(writes[0].params.turnId, "original-turn");
+    assert.deepEqual(writes[0].params.message, message);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+
+test("settlement replacing an in-flight Task append is written after the initial snapshot", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "pi-subagent-outbox-race-"));
+  const outbox = new PersistenceOutbox(dir, () => undefined);
+  let releaseFirst;
+  let firstStarted;
+  const started = new Promise((resolve) => { firstStarted = resolve; });
+  const pending = new Promise((resolve) => { releaseFirst = resolve; });
+  const written = [];
+  const host = { isAvailable: () => true, call: async (_method, params) => {
+    written.push(params.message);
+    if (written.length === 1) {
+      firstStarted();
+      await pending;
+    }
+    return {};
+  } };
+  try {
+    const entry = { key: "message:session:task", sessionId: "session", turnId: "turn" };
+    await outbox.enqueue({ ...entry, message: { status: "running" } }, () => host);
+    await started;
+    await outbox.enqueue({ ...entry, message: { status: "completed" } }, () => host);
+    releaseFirst();
+    await outbox.flush(() => host);
+    assert.deepEqual(written, [{ status: "running" }, { status: "completed" }]);
+    assert.equal(outbox.size(), 0);
+  } finally {
+    releaseFirst();
+    await outbox.flush(() => host);
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/test/subagent-topology.test.mjs
+++ b/apps/desktop/test/subagent-topology.test.mjs
@@ -262,7 +262,7 @@ test("ignores roster entries that report no error at all", () => {
   assert.equal(failures.size, 0);
 });
 
-test("a Task row never carries its own failure, only lifecycle rows do", () => {
+test("a refreshed Task row carries its terminal failure before lifecycle polling", () => {
   const failures = collectDelegationFailures([
     {
       kind: "tool",
@@ -272,14 +272,14 @@ test("a Task row never carries its own failure, only lifecycle rows do", () => {
           details: {
             delegationId: "d1",
             status: "failed",
-            error: { code: "NOPE", message: "not a carrier" },
+            error: { code: "PROVIDER_ERROR", message: "provider failed" },
           },
         },
       },
     },
   ]);
 
-  assert.equal(failures.size, 0);
+  assert.deepEqual(failures.get("d1"), { code: "PROVIDER_ERROR", message: "provider failed" });
 });
 
 test("a finished turn treats leftover running delegates as aborted", () => {
@@ -429,4 +429,26 @@ test("topology elapsed bounds follow this card's Task ids, not a later fan-out",
     ),
     { startedAt: 1_000, completedAt: 5_000 },
   );
+});
+
+
+test("settled Task snapshots outrank stale lifecycle polling during a parallel fan-out", () => {
+  const first = task("first", "success", "completed", { startedAt: 1000, completedAt: 5000 });
+  const second = task("second", "success", "running", { startedAt: 1100 });
+  const stalePoll = lifecycle("TaskList", { delegations: [
+    { delegationId: "first", status: "running", startedAt: 1000 },
+    { delegationId: "second", status: "running", startedAt: 1100 },
+  ] });
+  const items = [first, second, stalePoll];
+  const statuses = collectDelegationStatuses(items, { turnLive: true });
+  assert.equal(subagentOutcome(first.message, statuses), "completed");
+  assert.equal(subagentOutcome(second.message, statuses), "running");
+  assert.deepEqual(summarizeSubagentActivity([first, second], statuses), {
+    total: 2, finished: 1, running: 1, issues: 0, warnings: 0,
+  });
+  assert.deepEqual(collectDelegationTimings(items).get("first"), {
+    startedAt: 1000, completedAt: 5000,
+  });
+  // History reconstruction must preserve success, rather than infer abortion.
+  assert.equal(collectDelegationStatuses(items, { turnLive: false }).get("first"), "completed");
 });

--- a/docs/spec/03-runtime/02-agent-runtime.md
+++ b/docs/spec/03-runtime/02-agent-runtime.md
@@ -645,6 +645,20 @@ core set rather than the on-demand catalog of §7.1:
   waits for each abort to settle, then persists `status: "stopped"` with
   `completedAt` on `details.stopped[]`. Stopped delegations read as `stopped`.
 
+**Live settlement.** When a delegate settles, the runtime refreshes its original
+`Task` transcript row with the terminal delegation summary (`status`,
+`completedAt`, counters, and failure details when present), using the existing
+full `message_end` snapshot. This does not depend on the parent calling
+`TaskWait` / `TaskList` / `TaskStop` or on other delegates finishing. The
+snapshot retains the Task call's identity, arguments, tool timing, and token
+usage; it does not execute the tool again or add usage to the parent turn.
+The initial Task result is emitted first even if the delegate settles before
+that result arrives. Electron persists the refreshed row through the normal
+message outbox so session switching and history reload preserve the outcome.
+An outbox write acknowledges only the snapshot sent to the host; a newer
+snapshot replacing the same message ID during that write remains queued.
+No new event type or storage schema is required.
+
 **Delegate loop.** A `SubagentRun` is a second pi `Agent` in the same sidecar
 process with the definition's system prompt, its (possibly pinned)
 provider/model, its declared tools, and the same host connection. A pinned or

--- a/docs/spec/04-ux/08-component-spec.md
+++ b/docs/spec/04-ux/08-component-spec.md
@@ -1890,6 +1890,11 @@ in place:
   transparent while streaming — no whole-turn tile wrapping thinking, tools, or
   answer fragments (D323). The card keeps 16px inset from its
   tile edge so the graph and any leftover rows do not sit on the border.
+- A delegate's terminal Task snapshot updates its topology node, settled count,
+  elapsed time, and open detail dock immediately, even while siblings or the
+  parent remain active. A completed delegate is green and stops spinning.
+  Terminal Task state takes precedence over older lifecycle polling snapshots
+  that still say `running`; the same outcome survives transcript reload.
 - A topology group stays live — open once, ticking elapsed, labelled working —
   while any of *its* delegates is still running, even when the parent has
   already moved on to a later processing group in the same turn. Elapsed time

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -6475,7 +6475,7 @@ needed.
 |---|---|
 | A — App startup | E2E-001, E2E-002, E2E-003, E2E-004, E2E-067, E2E-076, E2E-079, E2E-092, E2E-097, E2E-143, E2E-150, E2E-168, E2E-204 |
 | B — Model config | E2E-005, E2E-006, E2E-007, E2E-038, E2E-050, E2E-052, E2E-055, E2E-066, E2E-080, E2E-082, E2E-102c, E2E-102d, E2E-102e, E2E-151, E2E-154, E2E-163, E2E-166, E2E-172, E2E-174, E2E-197, E2E-005G, E2E-005J, E2E-199, E2E-201, E2E-202, E2E-203, E2E-205, E2E-206, E2E-209 |
-| C — Conversation & stream | E2E-008, E2E-008d, E2E-008a, E2E-009, E2E-010, E2E-011, E2E-011a, E2E-011b, E2E-011d, E2E-011e, E2E-011g, E2E-031, E2E-040, E2E-047, E2E-048, E2E-048A, E2E-049, E2E-052, E2E-053, E2E-054, E2E-055, E2E-059, E2E-059a, E2E-060c, E2E-060d, E2E-061, E2E-061a, E2E-062, E2E-064, E2E-065, E2E-068, E2E-071, E2E-073, E2E-074, E2E-075, E2E-081, E2E-083, E2E-084, E2E-086, E2E-087, E2E-088, E2E-088b, E2E-089, E2E-090, E2E-094, E2E-095, E2E-096, E2E-097, E2E-098, E2E-099, E2E-102, E2E-102a, E2E-102b, E2E-102c, E2E-102d, E2E-102g, E2E-106, E2E-109, E2E-111, E2E-114, E2E-116, E2E-117, E2E-118, E2E-119, E2E-120, E2E-121, E2E-218, E2E-219, E2E-AGENTS-001, E2E-142, E2E-144, E2E-145, E2E-146, E2E-146a, E2E-147, E2E-151, E2E-154, E2E-155, E2E-158, E2E-159, E2E-161, E2E-162, E2E-166, E2E-172, E2E-173, E2E-174, E2E-177, E2E-178, E2E-179, E2E-180, E2E-182, E2E-183, E2E-187, E2E-198, E2E-199, E2E-202, E2E-203, E2E-207, E2E-208, E2E-250, E2E-102i, E2E-PLUGIN-session-orchestrator-real-workers |
+| C — Conversation & stream | E2E-008, E2E-008d, E2E-008a, E2E-009, E2E-010, E2E-011, E2E-011a, E2E-011b, E2E-011d, E2E-011e, E2E-011g, E2E-031, E2E-040, E2E-047, E2E-048, E2E-048A, E2E-049, E2E-052, E2E-053, E2E-054, E2E-055, E2E-059, E2E-059a, E2E-060c, E2E-060d, E2E-061, E2E-061a, E2E-062, E2E-064, E2E-065, E2E-068, E2E-071, E2E-073, E2E-074, E2E-075, E2E-081, E2E-083, E2E-084, E2E-086, E2E-087, E2E-088, E2E-088b, E2E-089, E2E-090, E2E-094, E2E-095, E2E-096, E2E-097, E2E-098, E2E-099, E2E-102, E2E-102a, E2E-102b, E2E-102c, E2E-102d, E2E-102g, E2E-106, E2E-109, E2E-111, E2E-114, E2E-116, E2E-117, E2E-118, E2E-119, E2E-120, E2E-121, E2E-218, E2E-219, E2E-AGENTS-001, E2E-142, E2E-144, E2E-145, E2E-146, E2E-146a, E2E-147, E2E-151, E2E-154, E2E-155, E2E-158, E2E-159, E2E-161, E2E-162, E2E-166, E2E-172, E2E-173, E2E-174, E2E-177, E2E-178, E2E-179, E2E-180, E2E-182, E2E-183, E2E-187, E2E-198, E2E-199, E2E-202, E2E-203, E2E-207, E2E-208, E2E-250, E2E-102i, E2E-PLUGIN-session-orchestrator-real-workers, E2E-SUBAGENT-settlement-updates-before-parent-poll |
 | D — Workspace | E2E-012, E2E-013, E2E-022B, E2E-024I, E2E-047, E2E-049, E2E-057, E2E-058, E2E-060, E2E-068, E2E-075, E2E-078, E2E-153, E2E-158, E2E-182, E2E-187, E2E-252 |
 | D — Workspace (project ordering) | E2E-253 |
 | E — Tools & permissions | E2E-008a, E2E-014, E2E-015, E2E-016, E2E-017, E2E-018, E2E-019, E2E-024I, E2E-024K, E2E-040, E2E-049, E2E-074, E2E-093, E2E-097, E2E-099, E2E-100, E2E-101, E2E-102, E2E-102d, E2E-102e, E2E-102g, E2E-103, E2E-105, E2E-106, E2E-107, E2E-111, E2E-112, E2E-113, E2E-114, E2E-115, E2E-116, E2E-119, E2E-121, E2E-122, E2E-142, E2E-145, E2E-147, E2E-155, E2E-158, E2E-166, E2E-181 |
@@ -6484,7 +6484,7 @@ needed.
 | G — Plugins | E2E-022, E2E-022A, E2E-022B, E2E-022C, E2E-023, E2E-024, E2E-024B, E2E-024C, E2E-024D, E2E-024E, E2E-024W, E2E-024F, E2E-024G, E2E-024H, E2E-024I, E2E-024J, E2E-024K, E2E-024L, E2E-024M, E2E-024N, E2E-024O, E2E-024P, E2E-025, E2E-026, E2E-105, E2E-117, E2E-120, E2E-122, E2E-123, E2E-024Q, E2E-148, E2E-152, E2E-153 |
 | H — Diagnostics | E2E-027, E2E-031, E2E-034, E2E-042, E2E-096, E2E-098, E2E-104, E2E-107, E2E-108, E2E-109, E2E-110, E2E-113, E2E-115, E2E-116, E2E-118, E2E-121, E2E-146, E2E-146a, E2E-155, E2E-159, E2E-176, E2E-194, E2E-195 |
 | Security | E2E-028, E2E-029, E2E-030, E2E-024J, E2E-024K, E2E-024M, E2E-049, E2E-068, E2E-086, E2E-102c, E2E-102d, E2E-102e, E2E-105, E2E-106, E2E-107, E2E-108, E2E-109, E2E-110, E2E-112, E2E-113, E2E-115, E2E-116, E2E-117, E2E-119, E2E-121, E2E-122, E2E-123, E2E-142, E2E-148, E2E-151, E2E-153, E2E-158, E2E-187, E2E-196c, E2E-196b, E2E-196 |
-| Quality | E2E-032, E2E-033, E2E-039, E2E-043, E2E-044, E2E-045, E2E-046, E2E-047, E2E-048, E2E-048A, E2E-049, E2E-050, E2E-053, E2E-055, E2E-056, E2E-057, E2E-058, E2E-059, E2E-060, E2E-061, E2E-062, E2E-063, E2E-064, E2E-065, E2E-066, E2E-067, E2E-068, E2E-069, E2E-070, E2E-071, E2E-072, E2E-073, E2E-074, E2E-075, E2E-076, E2E-077, E2E-078, E2E-079, E2E-080, E2E-081, E2E-082, E2E-083, E2E-084, E2E-085, E2E-086, E2E-092, E2E-093, E2E-094, E2E-095, E2E-096, E2E-097, E2E-098, E2E-099, E2E-100, E2E-101, E2E-102, E2E-102a, E2E-102b, E2E-102c, E2E-102d, E2E-102e, E2E-103, E2E-AGENTS-001, E2E-021a, E2E-024N, E2E-059a, E2E-060b, E2E-060c, E2E-061a, E2E-073a, E2E-111, E2E-114, E2E-117, E2E-118, E2E-119, E2E-120, E2E-122, E2E-123, E2E-142, E2E-143, E2E-144, E2E-145, E2E-146, E2E-147, E2E-148, E2E-150, E2E-151, E2E-153, E2E-155, E2E-158, E2E-159, E2E-160, E2E-161, E2E-162, E2E-163, E2E-168, E2E-172, E2E-173, E2E-174, E2E-011g, E2E-176, E2E-177, E2E-178, E2E-179, E2E-180, E2E-181, E2E-182, E2E-183, E2E-186, E2E-187, E2E-194, E2E-195, E2E-196a, E2E-196b, E2E-196c, E2E-198, E2E-199, E2E-200, E2E-196, E2E-201, E2E-204, E2E-202, E2E-203, E2E-205, E2E-206, E2E-207, E2E-208, E2E-209, E2E-210, E2E-218, E2E-219, E2E-250, E2E-252, E2E-102i |
+| Quality | E2E-032, E2E-033, E2E-039, E2E-043, E2E-044, E2E-045, E2E-046, E2E-047, E2E-048, E2E-048A, E2E-049, E2E-050, E2E-053, E2E-055, E2E-056, E2E-057, E2E-058, E2E-059, E2E-060, E2E-061, E2E-062, E2E-063, E2E-064, E2E-065, E2E-066, E2E-067, E2E-068, E2E-069, E2E-070, E2E-071, E2E-072, E2E-073, E2E-074, E2E-075, E2E-076, E2E-077, E2E-078, E2E-079, E2E-080, E2E-081, E2E-082, E2E-083, E2E-084, E2E-085, E2E-086, E2E-092, E2E-093, E2E-094, E2E-095, E2E-096, E2E-097, E2E-098, E2E-099, E2E-100, E2E-101, E2E-102, E2E-102a, E2E-102b, E2E-102c, E2E-102d, E2E-102e, E2E-103, E2E-AGENTS-001, E2E-021a, E2E-024N, E2E-059a, E2E-060b, E2E-060c, E2E-061a, E2E-073a, E2E-111, E2E-114, E2E-117, E2E-118, E2E-119, E2E-120, E2E-122, E2E-123, E2E-142, E2E-143, E2E-144, E2E-145, E2E-146, E2E-147, E2E-148, E2E-150, E2E-151, E2E-153, E2E-155, E2E-158, E2E-159, E2E-160, E2E-161, E2E-162, E2E-163, E2E-168, E2E-172, E2E-173, E2E-174, E2E-011g, E2E-176, E2E-177, E2E-178, E2E-179, E2E-180, E2E-181, E2E-182, E2E-183, E2E-186, E2E-187, E2E-194, E2E-195, E2E-196a, E2E-196b, E2E-196c, E2E-198, E2E-199, E2E-200, E2E-196, E2E-201, E2E-204, E2E-202, E2E-203, E2E-205, E2E-206, E2E-207, E2E-208, E2E-209, E2E-210, E2E-218, E2E-219, E2E-250, E2E-252, E2E-102i, E2E-SUBAGENT-settlement-updates-before-parent-poll |
 | Quality (project ordering) | E2E-253 |
 | C — Conversation & stream (IME slash alias) | E2E-255 |
 | E — Tools & permissions (Skill residency) | E2E-254 |
@@ -6508,7 +6508,7 @@ needed.
 | M2 (IME slash alias) | E2E-255 |
 | M5 (Skill residency) | E2E-254 |
 | M6 | E2E-104, E2E-105, E2E-106, E2E-107, E2E-108, E2E-109, E2E-110, E2E-111, E2E-112, E2E-113, E2E-114, E2E-115, E2E-116, E2E-117, E2E-118, E2E-119, E2E-120, E2E-103, E2E-172 |
-| M6+ | E2E-121, E2E-122, E2E-148, E2E-150, E2E-151, E2E-154, E2E-155, E2E-158, E2E-159, E2E-160, E2E-161, E2E-162, E2E-163, E2E-166, E2E-168, E2E-173, E2E-174, E2E-176, E2E-179, E2E-196a, E2E-196b, E2E-196c, E2E-198, E2E-199, E2E-200, E2E-202, E2E-203, E2E-205, E2E-209, E2E-210, E2E-212, E2E-213, E2E-214, E2E-215, E2E-216, E2E-217, E2E-218, E2E-219, E2E-257 |
+| M6+ | E2E-121, E2E-122, E2E-148, E2E-150, E2E-151, E2E-154, E2E-155, E2E-158, E2E-159, E2E-160, E2E-161, E2E-162, E2E-163, E2E-166, E2E-168, E2E-173, E2E-174, E2E-176, E2E-179, E2E-196a, E2E-196b, E2E-196c, E2E-198, E2E-199, E2E-200, E2E-202, E2E-203, E2E-205, E2E-209, E2E-210, E2E-212, E2E-213, E2E-214, E2E-215, E2E-216, E2E-217, E2E-218, E2E-219, E2E-257, E2E-SUBAGENT-settlement-updates-before-parent-poll |
 | M6+ (Session Orchestrator) | E2E-PLUGIN-session-orchestrator-real-workers |
 | Post-MVP | E2E-022A, E2E-022B, E2E-022C, E2E-024I, E2E-024J, E2E-024K, E2E-024L, E2E-024M (plugin roadmap R2/R3/R6) |
 | Post-baseline local automation | E2E-220 |
@@ -8178,8 +8178,30 @@ This test plan spec is accepted when:
 - **Status**: Documented; desktop journey pending. The failure card's data
   source is unit-tested in `subagent-topology.test.mjs`: a settled delegation's
   `error: { code, message }` read from `TaskWait` `delegations[]` and `TaskStop`
-  `stopped[]`, last-write-wins across rows, entries without an error, and the
-  `Task` row that must never carry one.
+  `stopped[]`, lifecycle row ordering, entries without an error, and the
+  terminal Task snapshot that carries a failure before parent polling.
+
+#### E2E-SUBAGENT-settlement-updates-before-parent-poll
+
+- **Preconditions**: An Agent session with two parallel delegates; one can
+  finish while the other continues and the parent does not poll lifecycle tools.
+- **Steps**: 1) Start both delegates and open the first delegate's detail dock.
+  2) Optionally let TaskList report both as running. 3) Complete only the first
+  delegate while the parent turn remains live. 4) Switch sessions and return,
+  then reload history after the turn finishes. 5) Repeat with failed and stopped
+  delegates, and with a delegate finishing before its Task result arrives.
+- **Expected**: The settled node stops spinning immediately, its status is
+  completed (green) or the actual failure/stop outcome, and its elapsed time
+  stops increasing. The sibling remains running; the aggregate reads one of
+  two settled. The open dock updates with the same status and failure details.
+  A stale running TaskList snapshot cannot undo settlement. Reload preserves
+  the actual terminal outcome and original Task identity, arguments, and usage.
+- **Specs linked**: `03-runtime/02-agent-runtime.md` §Subagents,
+  `04-ux/08-component-spec.md` delegation topology
+- **Acceptance criterion**: C, Quality
+- **Milestone**: M6+
+- **Status**: Runtime event-order and renderer projection regressions automated;
+  desktop journey documented. Required suites: `test:e2e`, `test:e2e:subagents`.
 
 #### E2E-161: A delegation lifecycle row reads as a subagent row
 

--- a/packages/agent-runtime/src/delegation-message.ts
+++ b/packages/agent-runtime/src/delegation-message.ts
@@ -1,0 +1,51 @@
+import type { ToolTokenUsage, UiMessage } from "@pi-desktop/shared";
+
+/** Refresh the original Task row without repeating the tool or its token usage. */
+export function settledDelegationMessage(
+  message: UiMessage,
+  summary: Record<string, unknown>,
+): UiMessage {
+  const result = {
+    content: [
+      { type: "text", text: `Delegation ${summary.delegationId}: ${summary.status}.` },
+    ],
+    details: summary,
+  };
+  return { ...message, content: JSON.stringify(result), toolResult: result };
+}
+
+/** Retain the original, already completed Task call when its delegate starts. */
+export function taskMessageSnapshot({
+  toolCallId,
+  toolName,
+  args,
+  startedAt,
+  endedAt,
+  result,
+  toolUsage,
+}: {
+  toolCallId: string;
+  toolName: string;
+  args: unknown;
+  startedAt: number;
+  endedAt: number;
+  result: unknown;
+  toolUsage?: ToolTokenUsage;
+}): UiMessage {
+  return {
+    id: toolCallId,
+    role: "tool",
+    content: JSON.stringify(result),
+    createdAt: new Date(startedAt).toISOString(),
+    toolCallId,
+    toolName,
+    toolArgs: args,
+    toolStatus: "success",
+    toolResult: result,
+    toolCompletedAt: new Date(endedAt).toISOString(),
+    toolDurationMs: Math.max(0, endedAt - startedAt),
+    ...(toolUsage ? { toolUsage } : {}),
+    status: "complete",
+    isError: false,
+  };
+}

--- a/packages/agent-runtime/src/runtime.test.ts
+++ b/packages/agent-runtime/src/runtime.test.ts
@@ -5675,6 +5675,71 @@ describe("DesktopAgentRuntime subagents", () => {
     await runtime.dispose();
   });
 
+  it.each([false, true])(
+    "publishes a settled Task snapshot without polling (settles early: %s)",
+    async (settlesEarly) => {
+      const onEvent = vi.fn();
+      const runtime = createRuntime({ subagents: [explorer], onEvent, turnId: "original-turn" });
+      subagentRuns.instances.length = 0;
+      subagentRuns.deferred = true;
+      const task = taskTool(runtime);
+      const args = { agent: "explorer", task: "Find it." };
+      const started = await task.execute("task-live", args);
+      const sibling = await task.execute("task-sibling", args);
+      const internals = runtime as unknown as {
+        handleAgentEvent: (event: unknown) => Promise<void>;
+        delegations: Map<string, { status: string }>;
+      };
+      const handle = internals.handleAgentEvent.bind(runtime);
+      const settle = async () => {
+        subagentRuns.resolveRun!({
+          agentName: "explorer", status: "completed", report: "Done", turns: 1, toolCalls: 0,
+        });
+        await vi.waitFor(() =>
+          expect(internals.delegations.get(started.details.delegationId)?.status).toBe("completed"),
+        );
+      };
+      try {
+        await handle({ type: "tool_execution_start", toolName: "Task", toolCallId: "task-live", args });
+        if (settlesEarly) await settle();
+        await handle({
+          type: "tool_execution_end", toolName: "Task", toolCallId: "task-live",
+          result: started, isError: false,
+        });
+        if (!settlesEarly) await settle();
+        const events = onEvent.mock.calls.map(([envelope]) => envelope);
+        const snapshots = events.filter((envelope) =>
+          envelope.event.type === "message_end" && envelope.event.message.role === "tool",
+        );
+        expect(snapshots).toHaveLength(1);
+        expect(snapshots[0]).toMatchObject({
+          turnId: "original-turn",
+          event: { message: {
+            id: "task-live", toolName: "Task", toolArgs: args, toolStatus: "success",
+            toolResult: { details: {
+              delegationId: started.details.delegationId,
+              status: "completed", completedAt: expect.any(Number),
+            } },
+          } },
+        });
+        const initialStart = events.find((envelope) => envelope.event.type === "tool_start");
+        const initialEnd = events.find((envelope) => envelope.event.type === "tool_end");
+        expect(snapshots[0].event.message).toMatchObject({
+          createdAt: new Date(initialStart.ts).toISOString(),
+          toolCompletedAt: new Date(initialEnd.ts).toISOString(),
+          toolDurationMs: initialEnd.ts - initialStart.ts,
+          toolUsage: initialEnd.event.toolUsage,
+        });
+        expect(internals.delegations.get(sibling.details.delegationId)?.status).toBe("running");
+        const types = events.map((envelope) => envelope.event.type);
+        expect(types.indexOf("tool_end")).toBeLessThan(types.indexOf("message_end"));
+      } finally {
+        await runtime.dispose();
+        subagentRuns.deferred = false;
+      }
+    },
+  );
+
   it("converges through TaskWait with reports and statuses", async () => {
     const runtime = createRuntime({ subagents: [explorer] });
     subagentRuns.calls.length = 0;

--- a/packages/agent-runtime/src/runtime.ts
+++ b/packages/agent-runtime/src/runtime.ts
@@ -1,5 +1,9 @@
 import { randomUUID } from "node:crypto";
 import {
+  settledDelegationMessage,
+  taskMessageSnapshot,
+} from "./delegation-message.js";
+import {
   Agent,
   BACKGROUND_CONTEXT,
   compact,
@@ -317,6 +321,9 @@ export type DelegationStatus =
  */
 export type DelegationRecord = {
   delegationId: string;
+  /** Original Task transcript snapshot, available after its immediate result. */
+  taskMessage?: UiMessage;
+  taskTurnId?: string;
   agentName: string;
   modelId: string;
   thinkingLevel: SubagentThinkingLevel;
@@ -1456,7 +1463,7 @@ export class DesktopAgentRuntime {
   private suppressProgressTurnRunEnd = false;
   private activeToolCalls = new Map<
     string,
-    { toolName: string; args: unknown }
+    { toolName: string; args: unknown; startedAt: number }
   >();
   private pendingAskTools = new Map<
     string,
@@ -3467,6 +3474,7 @@ Delegation rules:
         });
         const record: DelegationRecord = {
           delegationId,
+          taskTurnId: this.turnId,
           agentName: definition.name,
           modelId: provider.modelId,
           thinkingLevel,
@@ -3592,9 +3600,21 @@ Delegation rules:
     if (result.usage) {
       this.turnSubagentUsage = addUsage(this.turnSubagentUsage, result.usage);
     }
+    this.publishDelegationSettlement(record);
     record.resolveCompletion();
     this.refreshDelegationWait();
     this.pruneFinishedDelegations();
+  }
+
+  private publishDelegationSettlement(record: DelegationRecord): void {
+    if (!record.taskMessage || record.status === "running") return;
+    this.emit(
+      {
+        type: "message_end",
+        message: settledDelegationMessage(record.taskMessage, delegationSummary(record)),
+      },
+      record.taskTurnId,
+    );
   }
 
   /** Cap retained history so a long session cannot grow the registry forever.
@@ -4447,11 +4467,11 @@ Delegation rules:
     };
   }
 
-  private emit(event: AgentEventEnvelope["event"], turnId?: string) {
+  private emit(event: AgentEventEnvelope["event"], turnId?: string, ts = Date.now()) {
     this.onEvent({
       sessionId: this.sessionId,
       turnId: turnId ?? this.turnId,
-      ts: Date.now(),
+      ts,
       event,
     });
   }
@@ -6077,19 +6097,22 @@ Delegation rules:
         }
         break;
       }
-      case "tool_execution_start":
+      case "tool_execution_start": {
+        const startedAt = Date.now();
         this.clearAgentActivity();
         this.activeToolCalls.set(event.toolCallId, {
           toolName: event.toolName,
           args: event.args,
+          startedAt,
         });
         this.emit({
           type: "tool_start",
           toolCallId: event.toolCallId,
           toolName: event.toolName,
           args: event.args,
-        });
+        }, undefined, startedAt);
         break;
+      }
       case "tool_execution_update":
         this.emit({
           type: "tool_update",
@@ -6130,7 +6153,24 @@ Delegation rules:
             result: event.result,
             isError: event.isError,
             ...(toolUsage ? { toolUsage } : {}),
-          });
+          }, undefined, endedAt);
+          if (activeTool?.toolName === SUBAGENT_TOOL_NAME && isRecord(event.result)) {
+            const details = event.result.details;
+            const record = isRecord(details) && typeof details.delegationId === "string"
+              ? this.delegations.get(details.delegationId)
+              : undefined;
+            if (record) {
+              record.taskMessage = taskMessageSnapshot({
+                ...activeTool,
+                toolCallId: event.toolCallId,
+                result: event.result,
+                endedAt,
+                ...(toolUsage ? { toolUsage } : {}),
+              });
+              // A fast delegate may settle before its Task tool_end arrives.
+              this.publishDelegationSettlement(record);
+            }
+          }
         }
         break;
       case "turn_end":


### PR DESCRIPTION
多个子代理并行运行时，已完成的子代理仍可能显示转圈：运行时已经记录终态，但界面依赖父代理后续调用 TaskWait / TaskList 才能得知完成状态。

本次在子代理结束时，通过现有 `message_end` 事件更新原 Task 消息并持久化，保留调用参数、原始计时和 usage。补齐子代理先于 Task 结果完成的竞态，让终态快照优先于旧的 running 轮询结果，并修复 outbox 在写入期间被同一消息的新快照替换后，误删尚未写入终态的问题。

Closes #238.

验证（提交 `75547c3`，macOS ARM64）：

- `pnpm build:js`、desktop typecheck、项目 lint 通过。
- Runtime / subagent 回归 168 项、桌面子代理 / outbox 回归 97 项通过。
- Host smoke 18 项通过；真实模型与流式请求两项因未配置测试密钥跳过。
- 子代理 E2E 18 项、Electron boot 检查通过。
- 覆盖无需父代理轮询的终态事件、提前完成、旧状态优先级、失败与计时，以及 outbox 恢复和并发写入。

同步更新了 runtime、UI 规格和 E2E 场景文档；没有新增协议或数据库 schema。真实供应商多子代理动态 UI 场景未运行，未将其记为通过。
