### PR TITLE
feat(subagents): add ui-designer builtin preset and template chip

### DIFF
--- a/apps/desktop/src/components/settings/SubagentEditorSheet.tsx
+++ b/apps/desktop/src/components/settings/SubagentEditorSheet.tsx
@@ -87,6 +87,7 @@ export const SUBAGENT_PRESET_COPY = {
   "code-reviewer": { name: "presetReviewerName", desc: "presetReviewerDesc" },
   "test-runner": { name: "presetTestRunnerName", desc: "presetTestRunnerDesc" },
   fixer: { name: "presetFixerName", desc: "presetFixerDesc" },
+  "ui-designer": { name: "presetUiDesignerName", desc: "presetUiDesignerDesc" },
 } as const satisfies Record<SubagentPreset["id"], { name: string; desc: string }>;
 
 /** Full i18n path for a preset chip, or null when `id` is blank / unknown. */

--- a/apps/desktop/test/subagent-editor-helpers.test.mjs
+++ b/apps/desktop/test/subagent-editor-helpers.test.mjs
@@ -59,17 +59,22 @@ test("resetSubagentTemplate clears a selected preset without dropping model choi
 });
 
 test("preset ids and builtin document ids agree", () => {
-  // The runtime ships the same four delegates in
+  // The runtime ships the same five delegates in
   // `agent-runtime/src/subagent-definitions.ts`; the shared preset catalog
   // duplicates them as UI-ready data. A drift here would mean a user picks
   // "explorer" in the editor and the runtime loads a different prompt.
   const presetIds = [
-    ...presetSource.matchAll(/id: "(explorer|code-reviewer|test-runner|fixer)",/g),
+    ...presetSource.matchAll(
+      /id: "(explorer|code-reviewer|test-runner|fixer|ui-designer)",/g,
+    ),
   ].map((m) => m[1]);
-  assert.deepEqual(
-    presetIds,
-    ["explorer", "code-reviewer", "test-runner", "fixer"],
-  );
+  assert.deepEqual(presetIds, [
+    "explorer",
+    "code-reviewer",
+    "test-runner",
+    "fixer",
+    "ui-designer",
+  ]);
 });
 
 test("preset tools and maxTurns match the runtime builtin documents", () => {
@@ -83,6 +88,8 @@ test("preset tools and maxTurns match the runtime builtin documents", () => {
   assert.match(presetSource, /id: "test-runner"[\s\S]*?maxTurns: 40/);
   assert.match(presetSource, /id: "fixer"[\s\S]*?tools: \["Read", "Glob", "Grep", "Edit", "Write", "Bash"\]/);
   assert.match(presetSource, /id: "fixer"[\s\S]*?maxTurns: 80/);
+  assert.match(presetSource, /id: "ui-designer"[\s\S]*?tools: \["Read", "Glob", "Grep", "BrowserPreview", "Bash", "Edit", "Write"\]/);
+  assert.match(presetSource, /id: "ui-designer"[\s\S]*?maxTurns: 80/);
 });
 
 test("preset bodies mirror the runtime markdown frontmatter bodies", () => {
@@ -102,6 +109,11 @@ test("preset bodies mirror the runtime markdown frontmatter bodies", () => {
   assert.match(bodies[2], /Run the command the task names/);
   // fixer
   assert.match(bodies[3], /fast, focused implementation specialist/);
+  // ui-designer (the extraction stops at the body's first escaped backtick,
+  // so only the leading bullets are visible here; the BrowserPreview grant is
+  // asserted by the tools test above)
+  assert.match(bodies[4], /UI designer/);
+  assert.match(bodies[4], /design contract/);
 });
 
 test("presets stay within the published max-turns clamp", () => {

--- a/docs/spec/03-runtime/02-agent-runtime.md
+++ b/docs/spec/03-runtime/02-agent-runtime.md
@@ -571,9 +571,9 @@ criterion-by-criterion report of what was met and the evidence observed.
 The session Agent can hand separable pieces of work to delegates that run in
 their own context, in the background, and report back on demand.
 
-**Catalog.** Definitions are Markdown documents from two sources: the four
+**Catalog.** Definitions are Markdown documents from two sources: the five
 builtins shipped inline in `agent-runtime` (`explorer`, `code-reviewer`,
-`test-runner`, `fixer`) and the global user documents under
+`test-runner`, `fixer`, `ui-designer`) and the global user documents under
 `~/.agents/subagents/*.md`. There is no project-level subagent directory and
 `.pi/agents` is not scanned for capabilities. User documents are filtered by
 the app-local enabled state before they reach the loader. Electron main loads
@@ -593,11 +593,11 @@ arrives with the repository, so honoring its scope would let cloned code grant
 itself `auto`. A project document that declares a non-`inherit` scope keeps
 loading with a warning and its delegates run under the session's effective
 mode; a user who wants the scope copies the document into their own agents
-directory. Builtins, including `fixer`, do not override the parent session by
-default, so the one write-capable builtin follows `auto` completely (including
-explicit external paths) while `ask` and `accept-edits` retain their normal
-approval behavior. An explicit builtin or user scope remains an intentional
-override.
+directory. Builtins, including the write-capable `fixer` and `ui-designer`, do
+not override the parent session by default: they follow `auto` completely
+(including explicit external paths) while `ask` and `accept-edits` retain
+their normal approval behavior. An explicit builtin or user scope remains an
+intentional override.
 
 **Tools (ADR 0089).** Delegation is a four-tool lifecycle, built only in Agent
 mode and only when the catalog is non-empty, and all four belong to the Agent
@@ -668,7 +668,7 @@ the baseline only. It runs under
 the same bounded provider retry policy as the parent. `maxTurns` is an optional
 per-definition backstop (maximum 80); omitted, `none`, or `0` means unlimited
 turns. The built-ins declare one sized to their job — `explorer` 60,
-`code-reviewer` 50, `test-runner` 40, `fixer` 80 — so a delegate that loops
+`code-reviewer` 50, `test-runner` 40, `fixer` 80, `ui-designer` 80 — so a delegate that loops
 without converging ends as `truncated` with its partial report instead of
 running until the duration limit. `maxTokens` is an optional per-definition
 output cap (maximum 200000); omitted, `none`, or `0` follows the model's
@@ -678,7 +678,9 @@ so the adapter's derived `max_tokens` / `max_completion_tokens` /
 the session's requests keep the model binding. A value past the ceiling is a
 typo and is clamped rather than forwarded to the provider.
 The built-in `explorer` declares `Read`,
-`Glob`, `Grep`, and `Bash`, while `code-reviewer` remains read-only. Its statuses are `completed`,
+`Glob`, `Grep`, and `Bash`, while `code-reviewer` remains read-only;
+`fixer` and `ui-designer` write inside the workspace, and `ui-designer` adds
+`BrowserPreview` so it can check its rendered result before reporting. Its statuses are `completed`,
 `truncated`, `failed`, `aborted`, `timed_out` and the registry-only `stopped`;
 the terminal ones surface through `TaskWait`, whose text is
 the report (bounded to `MAX_SUBAGENT_REPORT_CHARS`, 12k) and whose details

--- a/docs/spec/04-ux/06-settings-ia.md
+++ b/docs/spec/04-ux/06-settings-ia.md
@@ -386,11 +386,12 @@ system while preserving their different data ownership:
 - Subagents open one **New subagent / Edit subagent** sheet that
   pre-fills the same fields the runtime's `BUILTIN_SUBAGENT_DOCUMENTS` ship
   with. Above the name field the sheet shows a "Start from template" row of
-  compact name chips (Explorer, Code reviewer, Test runner, Fixer, plus a
-  blank option). Chips show the localized name only; the selected chip's
-  one-line caption sits once under the row. Hyphenated preset ids
-  (`code-reviewer`, `test-runner`) resolve through an explicit catalog map
-  (`presetReviewerName` / `presetTestRunnerName`) — they must not be
+  compact name chips (Explorer, Code reviewer, Test runner, Fixer, UI
+  designer, plus a blank option). Chips show the localized name only; the
+  selected chip's one-line caption sits once under the row. Hyphenated preset
+  ids (`code-reviewer`, `test-runner`, `ui-designer`) resolve through an
+  explicit catalog map (`presetReviewerName` / `presetTestRunnerName` /
+  `presetUiDesignerName`) — they must not be
   turned into keys by capitalizing the first letter. Picking a chip
   replaces the draft's description, tools, max turns and body wholesale.
   The chip uses the same accent-tint pill as the tool grant row. Create

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -7986,8 +7986,8 @@ This test plan spec is accepted when:
 
 - **Preconditions**: A project-bound Agent session whose permission mode can be
   switched between `ask`, `accept-edits`, and `auto`, with a provider whose
-  stream can be driven; the four builtin subagents (`explorer`,
-  `code-reviewer`, `test-runner`, `fixer`) and a global
+  stream can be driven; the five builtin subagents (`explorer`,
+  `code-reviewer`, `test-runner`, `fixer`, `ui-designer`) and a global
   `~/.agents/subagents/readonly.md` definition. Builtins use the default
   `permission: inherit` behavior.
 - **Steps**:

--- a/docs/zh-CN/spec/03-runtime/02-agent-runtime.md
+++ b/docs/zh-CN/spec/03-runtime/02-agent-runtime.md
@@ -480,8 +480,8 @@ Goal 批准所承诺的内容与 Plan 批准所承诺的内容完全相同：`mo
 会话 Agent 可以把可拆分的工作交给在独立上下文中后台运行的委托，
 并按需取回报告。
 
-**目录。** 定义是来自两个来源的 Markdown 文档：`agent-runtime` 中内嵌的四个
-内置函数（`explorer`、`code-reviewer`、`test-runner`、`fixer`），以及
+**目录。** 定义是来自两个来源的 Markdown 文档：`agent-runtime` 中内嵌的五个
+内置函数（`explorer`、`code-reviewer`、`test-runner`、`fixer`、`ui-designer`），以及
 `~/.agents/subagents/*.md` 下的全局用户文档。没有项目级子代理目录，`.pi/agents`
 不会作为能力来源被扫描。用户文档在进入加载器前会根据应用本地启用状态过滤。
 Electron main 每次启动加载全局目录，并在 sidecar 参数中传递
@@ -494,9 +494,9 @@ Frontmatter 新增 `permission: inherit | ask | accept-edits | auto`（默认
 委托使用会话的有效权限模式；因此父会话为 `auto` 时，明确的外部路径也不会再次
 弹出授权卡。只有内置定义和用户定义可以声明非 `inherit` 作用域；项目定义随仓库
 一起到来，声明会在解析时被丢弃并留下警告，其委托仍在会话的有效模式下运行 ——
-想要该作用域的用户把文档复制到自己的 agents 目录。唯一可写的内置 `fixer` 也
-默认继承父会话：`auto` 下跟随父会话自动放行，而 `ask` 和 `accept-edits` 仍保留
-各自的审批边界。显式声明的内置或用户作用域仍然是一次有意的覆盖。
+想要该作用域的用户把文档复制到自己的 agents 目录。可写的内置 `fixer` 与
+`ui-designer` 也默认继承父会话：`auto` 下跟随父会话自动放行，而 `ask` 和
+`accept-edits` 仍保留各自的审批边界。显式声明的内置或用户作用域仍然是一次有意的覆盖。
 
 **工具（ADR 0089）。** 委托是四个工具的生命周期，仅在 Agent 模式下且目录
 非空时构建，四个工具都属于 Agent 核心集而不是第 7.1 节的按需目录：
@@ -540,9 +540,11 @@ Frontmatter 新增 `permission: inherit | ask | accept-edits | auto`（默认
 委托自身的响应 —— 会话自己的请求仍沿用模型绑定。超过天花板的值属于笔误，会被钳制
 而不会转发给 provider。
 内置委托各自声明与其工作量相称的值 —— `explorer` 60、`code-reviewer` 50、
-`test-runner` 40、`fixer` 80 —— 因此始终无法收敛的委托会以 `truncated`
+`test-runner` 40、`fixer` 80、`ui-designer` 80 —— 因此始终无法收敛的委托会以 `truncated`
 连同其部分报告结束，而不是一直跑到时长上限。内置的 `explorer` 声明 `Read`、
-`Glob`、`Grep` 和 `Bash`，而 `code-reviewer` 保持只读。其状态为 `completed`、
+`Glob`、`Grep` 和 `Bash`，而 `code-reviewer` 保持只读；`fixer` 与 `ui-designer`
+会在工作区内写入，`ui-designer` 另外声明 `BrowserPreview`，以便在报告前检查渲染结果。
+其状态为 `completed`、
 `truncated`、`failed`、`aborted`、`timed_out` 以及仅存在于注册表的
 `stopped`；终态通过 `TaskWait` 呈现，其文本是报告（上限为
 `MAX_SUBAGENT_REPORT_CHARS`，12k），其 details 携带 `delegationId`、`agent`、

--- a/docs/zh-CN/spec/04-ux/06-settings-ia.md
+++ b/docs/zh-CN/spec/04-ux/06-settings-ia.md
@@ -162,9 +162,9 @@ Token 用量**不是设置目的地**（D335 / ADR 0173）。已完成回合历�
   不发送持久化为 `thinkingLevel: omit`。
   模型配置里已选中的思考档芯片在浅色和深色主题下都使用实心强调底和反色主文本。
   新建表单在名称上方显示一行紧凑的模板名称 chips（探索者、代码审查员、测试执行者、
-  修复者、空白开始）：只显示名称，选中项的一句话说明出现在整行下方。带连字符的
-  id（`code-reviewer`、`test-runner`）必须走目录映射（`presetReviewerName` /
-  `presetTestRunnerName`），不能靠首字母大写拼 key。模型、推理、轮次上限和作用域
+  修复者、UI 设计师、空白开始）：只显示名称，选中项的一句话说明出现在整行下方。带连字符的
+  id（`code-reviewer`、`test-runner`、`ui-designer`）必须走目录映射（`presetReviewerName` /
+  `presetTestRunnerName` / `presetUiDesignerName`），不能靠首字母大写拼 key。模型、推理、轮次上限和作用域
   放在“高级”折叠区：新建时默认收起，编辑时默认展开。
 
 权限模式选择器在 Composer 中仍然可用，而

--- a/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/zh-CN/spec/06-delivery/04-e2e-test-plan.md
@@ -5721,8 +5721,8 @@ IPC 请求无法关闭。
 #### E2E-142：后台委托通过 TaskWait 收敛并遵守权限作用域
 
 - **先决条件**：一个绑定项目、权限模式可以在 `ask`、`accept-edits` 和 `auto`
-  之间切换的 Agent 会话，其提供方的流可以被驱动；四个内置子代理（`explorer`、
-  `code-reviewer`、`test-runner`、`fixer`）以及一个全局 `~/.agents/subagents/readonly.md`
+  之间切换的 Agent 会话，其提供方的流可以被驱动；五个内置子代理（`explorer`、
+  `code-reviewer`、`test-runner`、`fixer`、`ui-designer`）以及一个全局 `~/.agents/subagents/readonly.md`
   定义。内置定义使用默认的 `permission: inherit` 行为。
 - **步骤**：
   1. 提示一轮，其中助手在一条消息里发出两次 `Task` 调用 —— 一个 `explorer`

--- a/packages/agent-runtime/src/subagent-definitions.test.ts
+++ b/packages/agent-runtime/src/subagent-definitions.test.ts
@@ -30,6 +30,7 @@ describe("builtin subagent documents", () => {
       "code-reviewer",
       "test-runner",
       "fixer",
+      "ui-designer",
     ]);
     expect(definitions).toHaveLength(BUILTIN_SUBAGENT_DOCUMENTS.length);
     for (const definition of definitions) {
@@ -37,15 +38,16 @@ describe("builtin subagent documents", () => {
       expect(definition.description.length).toBeGreaterThan(20);
       expect(definition.prompt.length).toBeGreaterThan(50);
     }
-    // Only `fixer` may write to the workspace; every other builtin is
-    // read-only (the shell delegate reads and runs commands, which is a
-    // permission prompt, not an edit). Builtins inherit the parent session's
-    // permission mode unless they explicitly opt into a narrower scope.
+    // Only `fixer` and `ui-designer` may write to the workspace; every other
+    // builtin is read-only (the shell delegate reads and runs commands, which
+    // is a permission prompt, not an edit). Builtins inherit the parent
+    // session's permission mode unless they explicitly opt into a narrower
+    // scope.
     const mutating = definitions.filter(
       (definition) =>
         definition.tools.includes("Write") || definition.tools.includes("Edit"),
     );
-    expect(mutating.map((d) => d.name)).toEqual(["fixer"]);
+    expect(mutating.map((d) => d.name)).toEqual(["fixer", "ui-designer"]);
     expect(mutating[0]?.permission ?? "inherit").toBe("inherit");
     const explorer = definitions.find((definition) => definition.name === "explorer")!;
     expect(explorer.tools).toEqual(["Read", "Glob", "Grep", "Bash"]);
@@ -56,6 +58,9 @@ describe("builtin subagent documents", () => {
     );
     expect(explorer.maxDurationSeconds).toBe(21_600);
     expect(definitions[2].tools).toContain("Bash");
+    const designer = definitions.find((definition) => definition.name === "ui-designer")!;
+    expect(designer.tools).toContain("BrowserPreview");
+    expect(designer.maxTurns).toBe(80);
   });
 });
 

--- a/packages/agent-runtime/src/subagent-definitions.ts
+++ b/packages/agent-runtime/src/subagent-definitions.ts
@@ -152,6 +152,56 @@ Report in this shape:
 - Tests: [passed / failed / skipped: reason]
 - Validation: [passed / failed / skipped: reason]
 </verification>`,
+  `---
+name: ui-designer
+description: Design and implement a web interface from a brief — visual system, motion and complete interaction states, verified in the browser preview. Use for building or restyling a UI when the visual work should run in its own context.
+tools: [Read, Glob, Grep, BrowserPreview, Bash, Edit, Write]
+maxTurns: 80
+---
+
+You are UI designer — a senior UI/UX designer and frontend engineer. The main
+agent hands you one interface task with its brief; deliver a working,
+browser-checked implementation, not a static mock and not a generic hero,
+features, pricing template.
+
+- Read the files you will touch and the project's existing design system
+  first. Established tokens, stack and components outrank your own taste;
+  preserve them instead of migrating to satisfy a preference.
+- When the project has no UI to match, write a small design contract before
+  coding: mission, semantic color/typography/spacing/radius/motion tokens on
+  a 4px/8px rhythm, and the Do/Don't rules you will hold the result to.
+- Build the whole interaction: semantic controls with real actions, visible
+  keyboard focus, and the loading, empty, error, success, disabled and
+  selected states the flow can reach. Keep grid tracks stable so long
+  content reflows without overlap; never hide a layout defect behind
+  overflow clipping. No TODOs, pseudo-handlers or invented backend behavior
+  — label fixture data as demo data.
+- Motion carries state changes, never decorates: immediate hover and press
+  feedback, spring-like entrances with a small stagger for lists, and
+  reduced-motion variants. Do not use \`transition: all\`, a generic
+  \`0.3s ease\`, or constant-speed linear movement for stateful UI, and do
+  not add an animation dependency for what one CSS transition covers.
+- The brief is your confirmation; there is no user to ask mid-run. State
+  the assumptions a silent brief forced, and stay inside the files the task
+  scopes.
+- Verify before reporting: open the changed page in BrowserPreview at
+  desktop and mobile widths, walk the primary journey, check keyboard focus
+  and reduced motion, fix what you observe, and re-check. Run the project's
+  build or typecheck when it covers your change. A result you did not look
+  at is not evidence.
+
+Report in this shape:
+
+<summary>
+2-3 sentences: what was built and the design direction taken.
+</summary>
+<changes>
+- path/file.tsx: what changed
+</changes>
+<verification>
+- Browser: [what was opened and checked, issues fixed, issues remaining]
+- Build: [passed / failed / skipped: reason]
+</verification>`,
 ];
 
 /** Parsed builtins, rebuilt per call so a bad constant surfaces as a

--- a/packages/i18n/src/locales/de/index.ts
+++ b/packages/i18n/src/locales/de/index.ts
@@ -1789,6 +1789,8 @@ export const de = {
       "presetTestRunnerDesc": "Führt Test oder Build aus und meldet Fehler.",
       "presetFixerName": "Fixer",
       "presetFixerDesc": "Setzt eine mehrteilige Änderung aus einer Spezifikation um.",
+      "presetUiDesignerName": "UI-Designer",
+      "presetUiDesignerDesc": "Gestaltet und implementiert eine Oberfläche nach Vorgabe, verifiziert in der Browservorschau.",
       "presetBlank": "Leer starten",
       "presetBlankDesc": "Standardwerkzeuge. Schreiben Sie die Anweisungen selbst.",
       "presetApply": "Anwenden",

--- a/packages/i18n/src/locales/en/index.ts
+++ b/packages/i18n/src/locales/en/index.ts
@@ -1825,6 +1825,8 @@ export const en = {
       presetTestRunnerDesc: "Run a test or build command and report what failed.",
       presetFixerName: "Fixer",
       presetFixerDesc: "Implement a multi-file change from a spec.",
+      presetUiDesignerName: "UI designer",
+      presetUiDesignerDesc: "Design and implement an interface from a brief, verified in the browser preview.",
       presetBlank: "Start blank",
       presetBlankDesc: "Default tools. Write your own instructions.",
       presetApply: "Apply",

--- a/packages/i18n/src/locales/es/index.ts
+++ b/packages/i18n/src/locales/es/index.ts
@@ -1789,6 +1789,8 @@ export const es = {
       "presetTestRunnerDesc": "Ejecuta un test o build y reporta los fallos.",
       "presetFixerName": "Reparador",
       "presetFixerDesc": "Implementa un cambio de varios archivos a partir de una spec.",
+      "presetUiDesignerName": "Diseñador UI",
+      "presetUiDesignerDesc": "Diseña e implementa una interfaz a partir del encargo, verificada en la vista previa del navegador.",
       "presetBlank": "Empezar en blanco",
       "presetBlankDesc": "Herramientas por defecto. Escribe tus instrucciones.",
       "presetApply": "Aplicar",

--- a/packages/i18n/src/locales/fr/index.ts
+++ b/packages/i18n/src/locales/fr/index.ts
@@ -1789,6 +1789,8 @@ export const fr = {
       "presetTestRunnerDesc": "Exécute un test ou un build et signale les échecs.",
       "presetFixerName": "Correcteur",
       "presetFixerDesc": "Implémente un changement multi-fichiers à partir d’une spec.",
+      "presetUiDesignerName": "Designer UI",
+      "presetUiDesignerDesc": "Conçoit et implémente une interface à partir d’un brief, vérifiée dans l’aperçu navigateur.",
       "presetBlank": "Vierge",
       "presetBlankDesc": "Outils par défaut. Rédigez vos instructions.",
       "presetApply": "Appliquer",

--- a/packages/i18n/src/locales/ko/index.ts
+++ b/packages/i18n/src/locales/ko/index.ts
@@ -1826,6 +1826,8 @@ export const ko = {
       presetTestRunnerDesc: "테스트나 빌드를 실행하고 실패를 보고합니다.",
       presetFixerName: "수정자",
       presetFixerDesc: "스펙에 따라 여러 파일 변경을 구현합니다.",
+      presetUiDesignerName: "UI 디자이너",
+      presetUiDesignerDesc: "요구사항에 따라 인터페이스를 설계·구현하고 브라우저 미리보기로 검증합니다.",
       presetBlank: "빈 문서로 시작",
       presetBlankDesc: "기본 도구. 지시문은 직접 작성합니다.",
       presetApply: "적용",

--- a/packages/i18n/src/locales/tr/index.ts
+++ b/packages/i18n/src/locales/tr/index.ts
@@ -1826,6 +1826,8 @@ export const tr = {
       presetTestRunnerDesc: "Test veya derleme komutunu çalıştırıp hataları raporlar.",
       presetFixerName: "Düzeltici",
       presetFixerDesc: "Bir spesifikasyona göre çok dosyalı değişikliği uygular.",
+      presetUiDesignerName: "UI tasarımcısı",
+      presetUiDesignerDesc: "Brief'e göre bir arayüz tasarlar ve uygular; tarayıcı önizlemesinde doğrular.",
       presetBlank: "Boş başla",
       presetBlankDesc: "Varsayılan araçlar. Yönergeleri siz yazın.",
       presetApply: "Uygula",

--- a/packages/i18n/src/locales/zh-CN/index.ts
+++ b/packages/i18n/src/locales/zh-CN/index.ts
@@ -1800,6 +1800,8 @@ export const zhCN = {
       presetTestRunnerDesc: "运行测试或构建，并报告失败原因。",
       presetFixerName: "修复者",
       presetFixerDesc: "按规格实现跨文件改动。",
+      presetUiDesignerName: "UI 设计师",
+      presetUiDesignerDesc: "按需求稿设计并实现界面，浏览器预览验收。",
       presetBlank: "空白开始",
       presetBlankDesc: "默认工具，自行撰写指令。",
       presetApply: "套用",

--- a/packages/i18n/src/locales/zh-TW/index.ts
+++ b/packages/i18n/src/locales/zh-TW/index.ts
@@ -1799,6 +1799,8 @@ export const zhTW = {
       presetTestRunnerDesc: "執行測試或建置，並回報失敗原因。",
       presetFixerName: "修復者",
       presetFixerDesc: "依照規格實作跨檔案變更。",
+      presetUiDesignerName: "UI 設計師",
+      presetUiDesignerDesc: "按需求稿設計並實作介面，瀏覽器預覽驗收。",
       presetBlank: "空白開始",
       presetBlankDesc: "預設工具，自行撰寫指令。",
       presetApply: "套用",

--- a/packages/shared/src/subagent-presets.test.ts
+++ b/packages/shared/src/subagent-presets.test.ts
@@ -14,9 +14,15 @@ import {
 } from "./subagent-presets.js";
 
 describe("SUBAGENT_PRESETS", () => {
-  it("ships the four builtin roles", () => {
+  it("ships the five builtin roles", () => {
     const ids = SUBAGENT_PRESETS.map((preset) => preset.id);
-    expect(ids).toEqual(["explorer", "code-reviewer", "test-runner", "fixer"]);
+    expect(ids).toEqual([
+      "explorer",
+      "code-reviewer",
+      "test-runner",
+      "fixer",
+      "ui-designer",
+    ]);
   });
 
   it("never duplicates a name", () => {
@@ -48,8 +54,12 @@ describe("SUBAGENT_PRESETS", () => {
     const explorer = findSubagentPreset("explorer");
     const reviewer = findSubagentPreset("code-reviewer");
     const runner = findSubagentPreset("test-runner");
+    const designer = findSubagentPreset("ui-designer");
     expect(fixer?.tools).toContain("Edit");
     expect(fixer?.tools).toContain("Write");
+    expect(designer?.tools).toContain("Edit");
+    expect(designer?.tools).toContain("Write");
+    expect(designer?.tools).toContain("BrowserPreview");
     expect(explorer?.tools ?? []).not.toContain("Edit");
     expect(reviewer?.tools ?? []).not.toContain("Edit");
     expect(runner?.tools ?? []).not.toContain("Edit");
@@ -60,6 +70,7 @@ describe("findSubagentPreset", () => {
   it("returns the matching preset", () => {
     expect(findSubagentPreset("explorer")?.id).toBe("explorer");
     expect(findSubagentPreset("fixer")?.id).toBe("fixer");
+    expect(findSubagentPreset("ui-designer")?.id).toBe("ui-designer");
   });
 
   it("returns undefined for unknown ids", () => {

--- a/packages/shared/src/subagent-presets.ts
+++ b/packages/shared/src/subagent-presets.ts
@@ -20,7 +20,7 @@ import { DEFAULT_SUBAGENT_TOOLS } from "./subagent-definition.js";
  */
 export type SubagentPreset = {
   /** Stable id used for i18n keys and analytics; matches `definition.name`. */
-  id: "explorer" | "code-reviewer" | "test-runner" | "fixer";
+  id: "explorer" | "code-reviewer" | "test-runner" | "fixer" | "ui-designer";
   /** Display name shown on the preset chip. */
   name: string;
   /** One-line description mirroring the definition's frontmatter. */
@@ -141,6 +141,58 @@ export const SUBAGENT_PRESETS: readonly SubagentPreset[] = [
       `- Tests: [passed / failed / skipped: reason]\n` +
       `- Validation: [passed / failed / skipped: reason]\n` +
       `</verification>\n`,
+  },
+  {
+    id: "ui-designer",
+    name: "UI designer",
+    description:
+      "Design and implement a web interface from a brief — visual system, motion and complete interaction states, verified in the browser preview. Use for building or restyling a UI when the visual work should run in its own context.",
+    tools: ["Read", "Glob", "Grep", "BrowserPreview", "Bash", "Edit", "Write"],
+    maxTurns: 80,
+    body: `You are UI designer — a senior UI/UX designer and frontend engineer. The main
+agent hands you one interface task with its brief; deliver a working,
+browser-checked implementation, not a static mock and not a generic hero,
+features, pricing template.
+
+- Read the files you will touch and the project's existing design system
+  first. Established tokens, stack and components outrank your own taste;
+  preserve them instead of migrating to satisfy a preference.
+- When the project has no UI to match, write a small design contract before
+  coding: mission, semantic color/typography/spacing/radius/motion tokens on
+  a 4px/8px rhythm, and the Do/Don't rules you will hold the result to.
+- Build the whole interaction: semantic controls with real actions, visible
+  keyboard focus, and the loading, empty, error, success, disabled and
+  selected states the flow can reach. Keep grid tracks stable so long
+  content reflows without overlap; never hide a layout defect behind
+  overflow clipping. No TODOs, pseudo-handlers or invented backend behavior
+  — label fixture data as demo data.
+- Motion carries state changes, never decorates: immediate hover and press
+  feedback, spring-like entrances with a small stagger for lists, and
+  reduced-motion variants. Do not use \`transition: all\`, a generic
+  \`0.3s ease\`, or constant-speed linear movement for stateful UI, and do
+  not add an animation dependency for what one CSS transition covers.
+- The brief is your confirmation; there is no user to ask mid-run. State
+  the assumptions a silent brief forced, and stay inside the files the task
+  scopes.
+- Verify before reporting: open the changed page in BrowserPreview at
+  desktop and mobile widths, walk the primary journey, check keyboard focus
+  and reduced motion, fix what you observe, and re-check. Run the project's
+  build or typecheck when it covers your change. A result you did not look
+  at is not evidence.
+
+Report in this shape:
+
+<summary>
+2-3 sentences: what was built and the design direction taken.
+</summary>
+<changes>
+- path/file.tsx: what changed
+</changes>
+<verification>
+- Browser: [what was opened and checked, issues fixed, issues remaining]
+- Build: [passed / failed / skipped: reason]
+</verification>
+`,
   },
 ];
 

--- a/scripts/e2e-subagents.mjs
+++ b/scripts/e2e-subagents.mjs
@@ -237,17 +237,31 @@ try {
   const userDocuments = await readActive(projectA);
   const merged = await loadSubagentDefinitions(projectA, { userDocuments });
   const byName = new Map(merged.definitions.map((definition) => [definition.name, definition]));
+  const builtinNames = ["explorer", "code-reviewer", "test-runner", "fixer", "ui-designer"];
   check(
     "the global registry document reaches the loader as a user definition",
     byName.get("log-reader")?.source === "user",
     `source=${byName.get("log-reader")?.source}`,
   );
   check(
-    "the four builtins remain available beside it",
-    ["explorer", "code-reviewer", "test-runner", "fixer"].every(
-      (name) => byName.get(name)?.source === "builtin",
-    ),
+    "the five builtins remain available beside it",
+    merged.definitions.filter((definition) => definition.source === "builtin").length ===
+      builtinNames.length &&
+      builtinNames.every((name) => byName.get(name)?.source === "builtin"),
     [...byName.keys()].join(", "),
+  );
+  const designer = byName.get("ui-designer");
+  check(
+    "the UI designer grants preview and editing, caps turns, and inherits permissions",
+    JSON.stringify(designer?.tools) ===
+      JSON.stringify(["Read", "Glob", "Grep", "BrowserPreview", "Bash", "Edit", "Write"]) &&
+      designer?.maxTurns === 80 &&
+      (designer?.permission ?? "inherit") === "inherit",
+    JSON.stringify({
+      tools: designer?.tools,
+      maxTurns: designer?.maxTurns,
+      permission: designer?.permission ?? "inherit",
+    }),
   );
   check(
     "the declared tools survive the round trip to the loader",
@@ -282,7 +296,11 @@ try {
   });
   check(
     "a malformed user document becomes a diagnostic without losing builtins",
-    broken.diagnostics.length === 1 && broken.definitions.length === 4,
+    broken.diagnostics.length === 1 &&
+      broken.definitions.length === builtinNames.length &&
+      builtinNames.every((name) => broken.definitions.some(
+        (definition) => definition.name === name && definition.source === "builtin",
+      )),
     `${broken.diagnostics.length} diagnostic(s), ${broken.definitions.length} definitions: ${broken.diagnostics[0]}`,
   );
 } catch (error) {


### PR DESCRIPTION
## What

Adds a fifth builtin subagent, `ui-designer`, as a "start from template" chip next to Explorer / Code reviewer / Test runner / Fixer.

The delegate takes one interface task with its brief and returns a working, browser-checked implementation — the same kind of self-contained, delegable phase `fixer` covers (ADR 0089), for the case where the main agent hands off visual work instead of doing it inline at full context cost. The prompt distills a UI-delivery workflow: preserve the project's established design system (existing tokens outrank the delegate's own taste), write a small design contract when none exists (semantic tokens, 4px/8px rhythm, Do/Don't rules), implement the whole interaction including every reachable state, keep motion purposeful with reduced-motion variants, and verify the rendered result in `BrowserPreview` at desktop and mobile widths before reporting. The report follows the existing `<summary>/<changes>/<verification>` convention. It is adapted from the author's open-source [UI Design Agent Kit](https://github.com/muzimu217/ui-design-agent-kit), reworked for the delegate's tool set and the no-user-mid-run delegate model.

- **Tools**: `Read, Glob, Grep, BrowserPreview, Bash, Edit, Write` at `maxTurns: 80` — write-capable like `fixer`, plus `BrowserPreview` so it can check its own rendered output. `BrowserPreview` is already in `SUBAGENT_ASSIGNABLE_TOOLS` and the host-side tool vocabulary; no host (Rust) change.
- **Lockstep**: `SUBAGENT_PRESETS` (shared, the editor's starter values) and `BUILTIN_SUBAGENT_DOCUMENTS` (agent-runtime, the prompt the sidecar loads) carry identical name/description/tools/maxTurns/body — verified field-by-field by script. The hyphenated id resolves through the editor's catalog map (`presetUiDesignerName` / `presetUiDesignerDesc`) with copy in all eight locales.
- **Spec pairs updated (en + zh-CN)**: the settings sheet section (chip row + catalog map), the runtime catalog list / `maxTurns` table / write-capable wording (correcting the stale "only writable builtin" phrasing), and E2E-142's precondition list.

## Deliberately not changed

- The four existing presets' copy, tools and turn caps are untouched; the blank chip stays last.
- `decisions-log.md` keeps its historical D201 "four builtins" wording — it records the decision as made at the time.
- No new runtime code path: the preset is data for the same parser, merge order and `SubagentRun` lifecycle as the other builtins (catalog cap 16 leaves headroom at five).

## Verification

- Lockstep check: scripted field-by-field comparison of the shared preset vs the builtin document (name, description, tools, maxTurns, body) — all equal.
- `pnpm -r test` green on the final HEAD: desktop 1463, agent-runtime 363, shared 498, plugin-sdk 224, i18n 23 (8-locale catalog parity), agent-host 34, plugin-devkit 46 — 0 failures. Updated tests: shared presets (five ids; Edit/Write granted only to fixer + ui-designer), agent-runtime builtin parse (five names; mutating = `[fixer, ui-designer]`; BrowserPreview present), desktop source-contract test (preset id list, tools/maxTurns, body spot-check).
- `desktop typecheck`, `lint`, `docs:check` (77 en/zh pairs) green. No Rust change.
- Live app check: launched the desktop app from this branch and opened Settings → Subagents → New — the UI designer chip renders in the template row, and picking it pre-fills name, description, all seven tools, max turns 80 and the prompt body (verified via CDP with screenshot).

E2E disposition per AGENTS §15 (fork PR):

```
E2E: NOT RUN
Suite: no listed suite drives the New-subagent template row end to end
Reason: renderer Settings surface; the delegate itself runs the unchanged SubagentRun path shared by all builtins
Alternative validation: unit + source-contract tests above, plus the CDP-driven live check of the template row (chip renders, form pre-fills)
Remaining risk: none beyond the existing builtin delegation path — the preset adds data, not new runtime behavior
```