### PR TITLE
docs(session-orchestrator): document durable session routing

### DIFF
--- a/docs/adr/0237-session-orchestrator-as-a-plugin.md
+++ b/docs/adr/0237-session-orchestrator-as-a-plugin.md
@@ -2,6 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-09-13
+- Updated: 2026-09-13
 - Decision: D391
 - Related: ADR 0200, ADR 0203, ADR 0208, ADR 0062, ADR 0089
 
@@ -20,8 +21,8 @@ without moving orchestration into host-core.
 ## Decision
 
 Ship `pi.session-orchestrator` as an ordinary marketplace plugin. It registers the
-`SessionTask` Agent Tool with `spawn`, `send`, `status`, `wait`, `result`,
-`cancel`, and `list` actions.
+`SessionTask` Agent Tool with `spawn`, `send`, `supervise`, `status`, `wait`,
+`result`, `accept`, `cancel`, and `list` actions.
 
 - `spawn` uses `session/create` followed by `agent/prompt`, creating a new
   durable session with no copied transcript. It inherits the parent project,
@@ -30,13 +31,21 @@ Ship `pi.session-orchestrator` as an ordinary marketplace plugin. It registers t
   never deletes the session.
 - The plugin persists only the parent/worker relationship, task, status,
   timestamp, and bounded report in its private data directory. The host-owned
-  worker transcript remains the source of truth.
-- A parent may control only workers recorded under its own session id. Worker
+  worker transcript remains the source of truth. The canonical worker identity
+  in the tool response and relationship store is the original durable
+  `sessionId` returned by `session/create`; 0.2.x `workerSessionId` settings are
+  migrated on load and no second Work ID is created.
+- A parent may control only Worker Session IDs recorded under its own session
+  id. A `send` or `supervise` follow-up addresses those same Session IDs, so a
+  child retains its own context without creating a replacement session. Worker
   sessions cannot use the tool to create or control more workers. Active work
   is capped at four workers per parent and sixteen across the plugin.
-- Until a lifecycle subscription exists, `wait` performs bounded 750 ms
-  polling with a 100-second timeout, leaving headroom under the plugin tool
-  deadline, and returns only bounded final reports.
+- Until a lifecycle subscription exists, `wait` performs one-second lightweight
+  status polling with a 25-second default and 45-second maximum timeout. Each
+  desktop read is bounded at five seconds, report transcript reads are deferred
+  until a worker is no longer running, and a timeout returns `timedOut` so the
+  plugin tool does not occupy the host deadline indefinitely. The Agents panel
+  uses the same status-only refresh path.
 - A simple `Agents` work-panel view lists workers and offers status refresh,
   Open Session, and Stop.
 
@@ -65,14 +74,15 @@ after a plugin or app restart.
 
 The first version does not receive lifecycle events and therefore has bounded
 polling latency. The plugin also has a four-worker limit and does not provide
-worker-to-worker messaging. A dangerous host operation is never used for
-orchestration; any future extension must preserve the existing desktop-control
-permission and native-consent boundary.
+unscoped arbitrary-session control or worker-to-worker messaging. A dangerous
+host operation is never used for orchestration; any future extension must
+preserve the existing desktop-control permission and native-consent boundary.
 
 ## Verification
 
 The plugin runtime integration test covers three parallel real-session
-requests, parent scoping, persistence across reload, same-session follow-up,
-bounded report extraction, polling, and cancellation without deletion.
+requests, parent scoping, persistence across reload, canonical Session ID
+routing, same-session context reuse, bounded report extraction, timeout-safe
+status polling, legacy settings migration, and cancellation without deletion.
 Host-core tests cover the optional permission-inheritance input. The E2E plan records
 the live-provider journey as `E2E-PLUGIN-session-orchestrator-real-workers`.

--- a/docs/spec/06-delivery/04-e2e-test-plan.md
+++ b/docs/spec/06-delivery/04-e2e-test-plan.md
@@ -9660,21 +9660,28 @@ are withdrawn with ADR 0165.
   the parent Agent session has a configured authenticated provider/model and a
   project path. The parent is in Agent mode.
 - **Steps**: 1) Ask the parent to review Frontend, Electron, and Rust in
-  parallel. 2) Confirm that `SessionTask.spawn` returns three distinct worker
-  session ids and that each worker is visible in the normal session list. 3)
-  Confirm all three workers receive prompts without using `session/fork` and
-  can run concurrently. 4) Call `SessionTask.wait`, then `result` for each
-  worker. 5) Open one worker from the Agents panel, send it a follow-up, and
-  stop another worker. 6) Restart the plugin and confirm the relationship list
-  and durable worker sessions remain available.
+  parallel. 2) Confirm that `SessionTask.spawn` returns three distinct
+  original durable `sessionId` values and that each worker is visible in the
+  normal session list. 3) Confirm all three workers receive prompts without
+  using `session/fork` and can run concurrently. 4) Call `SessionTask.status`
+  while they are active and confirm it does not fetch worker transcripts. 5)
+  Call `SessionTask.wait` with its default bound, then `result` for each
+  worker. 6) Open one worker from the Agents panel, send it a follow-up using
+  the exact returned `sessionId`, and stop another worker. 7) Restart the
+  plugin and confirm the relationship list and durable worker sessions remain
+  available.
 - **Expected**: Each worker is a real durable session with the parent's
   project/model/thinking/permission ceiling and an independent empty
   transcript at creation. The parent receives only bounded final reports;
-  full worker transcripts remain inspectable in their own sessions. Send uses
-  the same worker id, cancel aborts without deletion, unrelated sessions and
-  the existing Task family are unchanged, and no localhost MCP call or token
-  access occurs. A worker cannot create another worker, and concurrency limits
-  fail closed.
+  full worker transcripts remain inspectable in their own sessions. `sessionId`
+  is the only canonical Worker identity and follow-up `send` reuses that same
+  session and context without creating a replacement. Status and panel refresh
+  use bounded lightweight polling; `wait` returns `timedOut` within its limit
+  instead of occupying the host tool deadline. Cancel aborts without
+  deletion, unrelated sessions and the existing Task family are unchanged,
+  and no localhost MCP call or token access occurs. A worker cannot create
+  another worker, unowned Session IDs are rejected, and concurrency limits fail
+  closed.
 - **Specs linked**: `07-plugins/03-plugin-api.md`,
   `07-plugins/04-plugin-security.md`, `07-plugins/11-plugin-storage-isolation.md`,
   `03-runtime/01-ipc-protocol.md`, `03-runtime/06-host-rpc-protocol.md`,


### PR DESCRIPTION
Synchronizes the Session Orchestrator architecture record and E2E scenario with plugin release 0.3.0.

- Documents original durable sessionId as the only canonical Worker identity.
- Documents same-session follow-up and cross-session routing by the recorded ID.
- Documents bounded status polling, timeout behavior, transcript-read deferral, and unowned-ID rejection.
- Records migration and validation coverage without changing host code or the Session database schema.

Validation: git diff check passed. This branch contains documentation only.