### PR TITLE
fix(tests): gate POSIX shell and Windows symlink capability assumptions

### DIFF
--- a/crates/host-core/src/tools/mod.rs
+++ b/crates/host-core/src/tools/mod.rs
@@ -2855,6 +2855,9 @@ mod tests {
         assert_eq!(full.lines().count(), lines, "spill kept every line");
     }
 
+    // Requires a POSIX shell; Windows resolves Bash to PowerShell (see
+    // powershell_preserves_utf8_errors_quotes_cwd_and_native_exit_codes).
+    #[cfg(unix)]
     #[tokio::test]
     async fn bash_stderr_keeps_the_tail() {
         // A failing command's actionable message is its last line.

--- a/packages/plugin-devkit/src/templates.test.ts
+++ b/packages/plugin-devkit/src/templates.test.ts
@@ -212,7 +212,18 @@ describe("check", () => {
 
   it("rejects symlinks, which host-core refuses to copy", async () => {
     const dir = await scaffolded("panel-basic");
-    await symlink(join(dir, "main.js"), join(dir, "link.js"));
+    const target = join(dir, "main.js");
+    const link = join(dir, "link.js");
+    try {
+      await symlink(target, link);
+    } catch (err) {
+      // Windows file symlinks need Developer Mode or elevation. A directory
+      // junction is still reported by walkPluginDir (Dirent.isSymbolicLink).
+      if ((err as NodeJS.ErrnoException).code !== "EPERM") throw err;
+      const junctionSrc = join(dir, "junction-src");
+      await mkdir(junctionSrc);
+      await symlink(junctionSrc, join(dir, "link-dir"), "junction");
+    }
     expect((await check(dir)).errors.map((e) => e.code)).toContain("package.symlink");
   });
 


### PR DESCRIPTION
### Problem

Two tests assert platform capabilities the host may not have on Windows (issue #210):

1. `tools::tests::bash_stderr_keeps_the_tail` (`crates/host-core/src/tools/mod.rs`) runs a POSIX `seq`/`printf` command. On Windows the Bash tool resolves to PowerShell, so the command never reaches a POSIX parser.
2. plugin-devkit `rejects symlinks` (`packages/plugin-devkit/src/templates.test.ts`) calls `fs.symlink` for a file, which needs Developer Mode or elevation on Windows (`EPERM`).

Neither is gated; `ci.yml` only runs `ubuntu-latest`, so the failure only shows up on local Windows.

### Solution

1. Gate `bash_stderr_keeps_the_tail` with `#[cfg(unix)]`, matching existing platform gates in the same crate. The PowerShell sibling test already covers shell behavior on Windows.
2. Keep Windows coverage of the symlink install-gate: try the file symlink first, and on `EPERM` fall back to a directory junction. `walkPluginDir` reports junctions via `Dirent.isSymbolicLink()`, so `package.symlink` is still asserted.

### Testing

- Command: `pnpm --dir packages/plugin-devkit exec vitest run src/templates.test.ts`
- Result: **30 passed** (includes the junction-fallback path on this Windows host)
- Lint: `pnpm run lint` clean
- Rust: no rustup toolchain on this host, so `cargo test` was not re-run here. The change is a `#[cfg(unix)]` attribute matching existing uses in the same crate; CI (ubuntu) will still execute the test.

### Issue alignment

- Addresses reporter notes in #210: suggested `#[cfg(unix)]` for the shell test and junction fallback (preferred over skip) for the symlink test so Windows keeps the install-gate coverage.
- Related #208 / #209 are separate Windows failures (not in this PR).

### Agent dimension

evaluation — test harness no longer assumes host platform capabilities the suite does not have.

### Core value

Windows 上 host-core/plugin-devkit 测试不再因缺少 POSIX shell 或 symlink 权限而误报，安装门禁覆盖仍保留。

Fixes #210