### PR TITLE
fix(subagents): align ui designer preview verification

### DIFF
--- a/docs/spec/03-runtime/02-agent-runtime.md
+++ b/docs/spec/03-runtime/02-agent-runtime.md
@@ -704,7 +704,10 @@ typo and is clamped rather than forwarded to the provider.
 The built-in `explorer` declares `Read`,
 `Glob`, `Grep`, and `Bash`, while `code-reviewer` remains read-only;
 `fixer` and `ui-designer` write inside the workspace, and `ui-designer` adds
-`BrowserPreview` so it can check its rendered result before reporting. Its statuses are `completed`,
+`BrowserPreview` so it can open and inspect its rendered result before reporting.
+`BrowserPreview` only opens a live-reloading workspace HTML page; responsive,
+keyboard-focus, and reduced-motion checks require project-provided browser
+tests or other tooling. Its statuses are `completed`,
 `truncated`, `failed`, `aborted`, `timed_out` and the registry-only `stopped`;
 the terminal ones surface through `TaskWait`, whose text is
 the report (bounded to `MAX_SUBAGENT_REPORT_CHARS`, 12k) and whose details

--- a/packages/agent-runtime/src/subagent-definitions.test.ts
+++ b/packages/agent-runtime/src/subagent-definitions.test.ts
@@ -5,6 +5,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_SUBAGENT_IDLE_TIMEOUT_SECONDS,
   MAX_SUBAGENT_PROVIDERS,
+  findSubagentPreset,
   subagentCanMutate,
   type SubagentDefinition,
 } from "@pi-desktop/shared";
@@ -61,6 +62,8 @@ describe("builtin subagent documents", () => {
     const designer = definitions.find((definition) => definition.name === "ui-designer")!;
     expect(designer.tools).toContain("BrowserPreview");
     expect(designer.maxTurns).toBe(80);
+    expect(designer.description).toBe(findSubagentPreset("ui-designer")?.description);
+    expect(designer.prompt).toBe(findSubagentPreset("ui-designer")?.body.trim());
   });
 });
 

--- a/packages/agent-runtime/src/subagent-definitions.ts
+++ b/packages/agent-runtime/src/subagent-definitions.ts
@@ -154,7 +154,7 @@ Report in this shape:
 </verification>`,
   `---
 name: ui-designer
-description: Design and implement a web interface from a brief — visual system, motion and complete interaction states, verified in the browser preview. Use for building or restyling a UI when the visual work should run in its own context.
+description: Design and implement a web interface from a brief — visual system, motion and complete interaction states, inspected in the browser preview or project browser tests. Use for building or restyling a UI when the visual work should run in its own context.
 tools: [Read, Glob, Grep, BrowserPreview, Bash, Edit, Write]
 maxTurns: 80
 ---
@@ -184,11 +184,16 @@ features, pricing template.
 - The brief is your confirmation; there is no user to ask mid-run. State
   the assumptions a silent brief forced, and stay inside the files the task
   scopes.
-- Verify before reporting: open the changed page in BrowserPreview at
-  desktop and mobile widths, walk the primary journey, check keyboard focus
-  and reduced motion, fix what you observe, and re-check. Run the project's
-  build or typecheck when it covers your change. A result you did not look
-  at is not evidence.
+- Verify before reporting: after the first meaningful visual edit, call
+  BrowserPreview with a workspace-relative HTML path and inspect the live-
+  reloading page it opens. BrowserPreview opens a page but does not provide
+  screenshots, viewport controls, DOM interaction, keyboard simulation or
+  reduced-motion emulation. Use project-provided browser or E2E tooling through
+  Bash for responsive, keyboard-focus and reduced-motion checks when available;
+  otherwise report those checks as skipped instead of implying BrowserPreview
+  performed them. Fix what you observe and re-check. Run the project's build or
+  typecheck when it covers your change. A result you did not look at is not
+  evidence.
 
 Report in this shape:
 

--- a/packages/shared/src/subagent-presets.ts
+++ b/packages/shared/src/subagent-presets.ts
@@ -146,7 +146,7 @@ export const SUBAGENT_PRESETS: readonly SubagentPreset[] = [
     id: "ui-designer",
     name: "UI designer",
     description:
-      "Design and implement a web interface from a brief — visual system, motion and complete interaction states, verified in the browser preview. Use for building or restyling a UI when the visual work should run in its own context.",
+      "Design and implement a web interface from a brief — visual system, motion and complete interaction states, inspected in the browser preview or project browser tests. Use for building or restyling a UI when the visual work should run in its own context.",
     tools: ["Read", "Glob", "Grep", "BrowserPreview", "Bash", "Edit", "Write"],
     maxTurns: 80,
     body: `You are UI designer — a senior UI/UX designer and frontend engineer. The main
@@ -174,11 +174,16 @@ features, pricing template.
 - The brief is your confirmation; there is no user to ask mid-run. State
   the assumptions a silent brief forced, and stay inside the files the task
   scopes.
-- Verify before reporting: open the changed page in BrowserPreview at
-  desktop and mobile widths, walk the primary journey, check keyboard focus
-  and reduced motion, fix what you observe, and re-check. Run the project's
-  build or typecheck when it covers your change. A result you did not look
-  at is not evidence.
+- Verify before reporting: after the first meaningful visual edit, call
+  BrowserPreview with a workspace-relative HTML path and inspect the live-
+  reloading page it opens. BrowserPreview opens a page but does not provide
+  screenshots, viewport controls, DOM interaction, keyboard simulation or
+  reduced-motion emulation. Use project-provided browser or E2E tooling through
+  Bash for responsive, keyboard-focus and reduced-motion checks when available;
+  otherwise report those checks as skipped instead of implying BrowserPreview
+  performed them. Fix what you observe and re-check. Run the project's build or
+  typecheck when it covers your change. A result you did not look at is not
+  evidence.
 
 Report in this shape:
 


### PR DESCRIPTION
Follow-up to #292.\n\nThe ui-designer builtin prompt now describes BrowserPreview accurately: it opens a workspace-relative, live-reloading HTML page but does not provide screenshots, viewport controls, DOM interaction, keyboard simulation, or reduced-motion emulation. The shared preset and runtime definition stay synchronized, and the runtime specification records the boundary.\n\nValidation:\n- @pi-desktop/shared tests: 249 passed\n- @pi-desktop/shared typecheck: passed\n- @pi-desktop/agent-runtime tests: 363 passed\n- @pi-desktop/agent-runtime typecheck: passed\n- host-core debug build: passed\n- subagents E2E: 19/19 passed